### PR TITLE
Include MDK-generated nodeId when registering a node.

### DIFF
--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -257,7 +257,9 @@ namespace mdk {
             node.service = service;
             node.version = version;
             node.address = address;
-            node.properties = {};
+
+            node.properties = { "datawire_nodeId": procUUID };
+
             _disco.register(node);
         }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk 2.0.0;
+package datawire_mdk 2.0.1;
 
 // DATAWIRE MDK
 

--- a/tests/source/start_trace.py
+++ b/tests/source/start_trace.py
@@ -10,7 +10,7 @@ mdk = start()
 def main():
     session = mdk.session()
     session.info("process1", "hello")
-    time.sleep(1)
+    time.sleep(5)
     sys.stdout.write(session.inject())
     sys.stdout.flush()
     mdk.stop()


### PR DESCRIPTION
Add the MDK-generated `nodeId` to the `Node` properties when registering a node.

Also increase the wait at the start of the logging tests, since it was a bit flaky with the shorter delay.
