### PR TITLE
HACK: potentially work around java reflection issue 

### DIFF
--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -248,6 +248,7 @@ namespace mdk {
     class MDKImpl extends MDK {
 
         Logger logger = new Logger("mdk");
+        Map<String,Object> _reflection_hack = null;
 
         MDKRuntime _runtime;
         Discovery _disco;
@@ -276,6 +277,7 @@ namespace mdk {
         }
 
         MDKImpl(MDKRuntime runtime) {
+            _reflection_hack = new Map<String,Object>();
             _runtime = runtime;
             if (!runtime.dependencies.hasService("failurepolicy_factory")) {
                 runtime.dependencies.registerService("failurepolicy_factory",


### PR DESCRIPTION
The hypothesis is statics get initialized differently and quark reflection doesn't boot up properly
