### PR TITLE
HACK: potentially work around java reflection issue

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.10
+current_version = 2.0.11
 commit = False
 tag = False
 tag_name = "v{new_version}"

--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_discovery 2.0.10;
+package datawire_mdk_discovery 2.0.11;
 
 include discovery-protocol-3.0.q;
 include synapse.q;

--- a/quark/introspection-1.0.q
+++ b/quark/introspection-1.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_introspection 2.0.10;
+package datawire_mdk_introspection 2.0.11;
 
 /* 
  * Copyright 2016 Datawire. All rights reserved.

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk 2.0.10;
+package datawire_mdk 2.0.11;
 
 // DATAWIRE MDK
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -248,6 +248,7 @@ namespace mdk {
     class MDKImpl extends MDK {
 
         Logger logger = new Logger("mdk");
+        Map<String,Object> _reflection_hack = null;
 
         MDKRuntime _runtime;
         Discovery _disco;
@@ -276,6 +277,7 @@ namespace mdk {
         }
 
         MDKImpl(MDKRuntime runtime) {
+            _reflection_hack = new Map<String,Object>();
             _runtime = runtime;
             if (!runtime.dependencies.hasService("failurepolicy_factory")) {
                 runtime.dependencies.registerService("failurepolicy_factory",

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_runtime 2.0.10;
+package datawire_mdk_runtime 2.0.11;
 
 include actors_core.q;
 include actors_promise.q;

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_protocol 2.0.10;
+package datawire_mdk_protocol 2.0.11;
 
 import quark.concurrent;
 import quark.reflect;

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_tracing 2.0.10;
+package datawire_mdk_tracing 2.0.11;
 
 include protocol-1.0.q;
 include introspection-1.0.q;

--- a/quark/util-1.0.q
+++ b/quark/util-1.0.q
@@ -1,6 +1,6 @@
 quark 1.0;
 
-package datawire_mdk_util 2.0.10;
+package datawire_mdk_util 2.0.11;
 
 use js bluebird 3.4.1;
 include mdk_promises.js;


### PR DESCRIPTION
The hypothesis is statics get initialized differently and quark reflection doesn't boot up properly
