### PR TITLE
Flask integration and a compliance suite for web framework integrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,13 @@ test: install-mdk test-python test-python3
 
 .PHONY: test-python
 test-python:
-	virtualenv/bin/py.test -n 4 -v unittests functionaltests
+	# Functional tests don't benefit from being run in another language, so
+	# we only run them under Python 3:
+	virtualenv/bin/py.test -n 4 -v unittests
 
 .PHONY: test-python3
 test-python3:
-	# Functional tests don't benefit from being run in another language:
-	virtualenv3/bin/py.test -n 4 -v unittests
+	virtualenv3/bin/py.test -n 4 -v unittests functionaltests
 
 release-minor:
 	virtualenv/bin/python scripts/release.py minor

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,11 @@ release-patch:
 	virtualenv/bin/python scripts/release.py patch
 
 # Packaging commands:
-output: $(wildcard quark/*.q) dist
-	rm -rf output
+output: $(wildcard quark/*.q) $(wildcard python/*.py) dist
+	rm -rf output output.temp
 	# Use installed Quark if we don't already have quark cli in PATH:
 	which quark || source ~/.quark/config.sh; quark compile --include-stdlib -o output.temp quark/mdk-2.0.q
+	cp python/*.py output.temp/py/mdk-2.0/mdk/
 	mv output.temp output
 
 dist:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,6 @@ twine==1.8.1
 pytest==3.0.1
 pytest-xdist==1.15.0
 future==0.15.2
+requests==2.11.1
+flask==0.11.1
+blinker==1.4

--- a/functionaltests/source/continue_trace.py
+++ b/functionaltests/source/continue_trace.py
@@ -2,48 +2,18 @@
 from __future__ import print_function
 
 import sys
-import time
 
 from mdk import start
 mdk = start()
 
-start = time.time()
-
-def got_logs(log_events, context):
-    results = set()
-    for event in log_events.result:
-        print(event.context, event.category, event.text)
-        if event.context.traceId in context:
-            results.add((event.category, event.text))
-    expected = set([("process1", "hello"), ("process2", "world")])
-
-    if expected == results:
-        print("Got expected messages!")
-        mdk.stop()
-    else:
-        print("No full results yet, will try again. Specifically got: " + repr(results))
-        read_logs(context)
-
-def got_error(error):
-    print("ERROR: " + error.toString())
-    mdk.stop()
-    sys.exit(1)
-
-def read_logs(context):
-    if time.time() - start > 60:
-        print("Took more than 60 seconds, giving up.")
-        sys.exit(1)
-    tracer = mdk._tracer
-    now = int(start * 1000)
-    tracer.query(now - 60000, now + 120000).andEither(
-        lambda events: got_logs(events, context), got_error)
+import read_logs
 
 def main():
     context = sys.argv[1]
+    expected = set([("process1", "hello"), ("process2", "world")])
     session = mdk.join(context)
     session.info("process2", "world")
-
-    read_logs(context)
+    read_logs.Retriever(context, expected, mdk).read_logs()
 
 if __name__ == '__main__':
     main()

--- a/functionaltests/source/create-context.py
+++ b/functionaltests/source/create-context.py
@@ -1,0 +1,14 @@
+"""
+Create an encoded MDK context and write it to standard out.
+"""
+
+import sys
+
+from mdk import start
+
+
+if __name__ == '__main__':
+    mdk = start()
+    sys.stdout.write(mdk.session().externalize())
+    sys.stdout.flush()
+    mdk.stop()

--- a/functionaltests/source/read_logs.py
+++ b/functionaltests/source/read_logs.py
@@ -1,0 +1,64 @@
+"""
+Read logs, ensure they contain expected results.
+
+Usage: read_logs.py <context_id> <expected-messages>
+
+The expected messages are passed as JSON-encoded parameter, a list of
+[<category>, <text>] lists.
+"""
+from __future__ import print_function
+
+import sys
+import time
+from json import loads
+
+from mdk import start
+
+
+class Retriever(object):
+    """Retrieve logs, make sure they include expected messages."""
+
+    def __init__(self, context, expected, mdk):
+        self.context = context
+        self.expected = expected
+        self.mdk = mdk
+        self.start = time.time()
+
+    def _got_logs(self, log_events):
+        results = set()
+        for event in log_events.result:
+            print(event.context, event.category, event.text)
+            if event.context.traceId in self.context:
+                results.add((event.category, event.text))
+
+        if self.expected == results:
+            print("Got expected messages!")
+            self.mdk.stop()
+        else:
+            print("No full results yet, will try again. Specifically got: " + repr(results))
+            self.read_logs()
+
+    def _got_error(self, error):
+        print("ERROR: " + error.toString())
+        self.mdk.stop()
+        sys.exit(1)
+
+    def read_logs(self):
+        if time.time() - self.start > 60:
+            print("Took more than 60 seconds, giving up.")
+            sys.exit(1)
+        tracer = self.mdk._tracer
+        now = int(self.start * 1000)
+        tracer.query(now - 60000, now + 120000).andEither(
+            lambda events: self._got_logs, self._got_error)
+
+
+def main():
+    mdk = start()
+    context = sys.argv[1]
+    expected = set(loads(sys.argv[1]))
+    Retriever(context, expected, mdk).read_logs()
+
+
+if __name__ == '__main__':
+    main()

--- a/functionaltests/source/read_logs.py
+++ b/functionaltests/source/read_logs.py
@@ -49,8 +49,8 @@ class Retriever(object):
             sys.exit(1)
         tracer = self.mdk._tracer
         now = int(self.start * 1000)
-        tracer.query(now - 60000, now + 120000).andEither(
-            lambda events: self._got_logs, self._got_error)
+        tracer.query(now - 60000, now + 120000).andEither(self._got_logs,
+                                                          self._got_error)
 
 
 def main():

--- a/functionaltests/test_endtoend.py
+++ b/functionaltests/test_endtoend.py
@@ -8,7 +8,7 @@ from random import random
 from subprocess import Popen, check_call, check_output
 from unittest import TestCase
 
-from .utils import CODE_PATH, run_python
+from utils import CODE_PATH, run_python
 
 def random_string():
     return "random_" + str(random())[2:]
@@ -28,7 +28,7 @@ def assertRegisteryDiscoverable(test, discover):
     address = random_string()
     p = Popen([sys.executable, os.path.join(CODE_PATH, "register.py"), service, address])
     test.addCleanup(lambda: p.kill())
-    resolved_address = discover(service)
+    resolved_address = discover(service).decode("utf-8")
     test.assertIn(address, resolved_address)
     return p, service
 
@@ -47,7 +47,7 @@ class PythonTests(TestCase):
         p.terminate()
         time.sleep(3)
         resolved_address = run_python("resolve.py", [service], output=True)
-        self.assertEqual("not found", resolved_address)
+        self.assertEqual(b"not found", resolved_address)
 
     def test_logging(self):
         """Minimal logging end-to-end test.
@@ -65,6 +65,7 @@ class PythonTests(TestCase):
         and they both get logged together.
         """
         context_id = run_python("start_trace.py", output=True)
+        print("context_id", context_id)
         run_python("continue_trace.py", [context_id])
 
 

--- a/functionaltests/test_endtoend.py
+++ b/functionaltests/test_endtoend.py
@@ -8,7 +8,7 @@ from random import random
 from subprocess import Popen, check_call, check_output
 from unittest import TestCase
 
-from utils import CODE_PATH, run_python
+from utils import CODE_PATH, ROOT_PATH, run_python
 
 def random_string():
     return "random_" + str(random())[2:]
@@ -33,20 +33,24 @@ def assertRegisteryDiscoverable(test, discover):
     return p, service
 
 
-class PythonTests(TestCase):
+class Python2Tests(TestCase):
     """Tests for Python usage of MDK API."""
+
+    python_binary = os.path.join(ROOT_PATH, "virtualenv/bin/python")
 
     def test_discovery(self):
         """Minimal discovery end-to-end test."""
         # 1. Services registered by one process can be looked up by another.
         p, service = assertRegisteryDiscoverable(
             self,
-            lambda service: run_python("resolve.py", [service], output=True))
+            lambda service: run_python(self.python_binary, "resolve.py",
+                                       [service], output=True))
 
         # 2. If the service is unregistered via MDK stop() then it is no longer resolvable.
         p.terminate()
         time.sleep(3)
-        resolved_address = run_python("resolve.py", [service], output=True)
+        resolved_address = run_python(self.python_binary, "resolve.py",
+                                      [service], output=True)
         self.assertEqual(b"not found", resolved_address)
 
     def test_logging(self):
@@ -56,7 +60,7 @@ class PythonTests(TestCase):
         """
         # Write some logs, waiting for them to arrive:
         service = random_string()
-        run_python("write_logs.py", [service])
+        run_python(self.python_binary, "write_logs.py", [service])
 
     def test_tracing(self):
         """Minimal tracing end-to-end test.
@@ -64,9 +68,15 @@ class PythonTests(TestCase):
         One process can start a session context and a second one can join it,
         and they both get logged together.
         """
-        context_id = run_python("start_trace.py", output=True)
+        context_id = run_python(self.python_binary, "start_trace.py", output=True)
         print("context_id", context_id)
-        run_python("continue_trace.py", [context_id])
+        run_python(self.python_binary, "continue_trace.py", [context_id])
+
+
+class Python3Tests(Python2Tests):
+    """Tests for Python 3 usage of MDK API."""
+
+    python_binary = os.path.join(ROOT_PATH, "virtualenv3/bin/python")
 
 
 class JavascriptTests(TestCase):

--- a/functionaltests/test_endtoend.py
+++ b/functionaltests/test_endtoend.py
@@ -5,31 +5,13 @@ import os
 import sys
 import time
 from random import random
-from subprocess import Popen, check_output, check_call
+from subprocess import Popen, check_call, check_output
 from unittest import TestCase
 
-CODE_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "source"))
-
+from .utils import CODE_PATH, run_python
 
 def random_string():
     return "random_" + str(random())[2:]
-
-def decoded_check_output(*args, **kwargs):
-    return check_output(*args, **kwargs).decode('utf-8')
-
-def run_python(command, extra_args=(), output=False):
-    """
-    Run a Python program.
-
-    Returns output if output=True, in which case stderr will cause error.
-    """
-    args = [sys.executable, os.path.join(CODE_PATH, command)] + list(extra_args)
-    if output:
-        command = decoded_check_output
-    else:
-        command = check_call
-    return command(args)
 
 
 def assertRegisteryDiscoverable(test, discover):
@@ -98,7 +80,7 @@ class JavascriptTests(TestCase):
         """Minimal discovery end-to-end test with a Javascript client."""
         assertRegisteryDiscoverable(
             self,
-            lambda service: decoded_check_output(
+            lambda service: check_output(
                 ["node", os.path.join(CODE_PATH, "resolve.js"), service]))
 
 
@@ -114,7 +96,7 @@ class RubyTests(TestCase):
         """Minimal discovery end-to-end test with a Javascript client."""
         assertRegisteryDiscoverable(
             self,
-            lambda service: decoded_check_output(
+            lambda service: check_output(
                 ["ruby", os.path.join(CODE_PATH, "resolve.rb"), service]))
 
 
@@ -136,7 +118,7 @@ class JavaTests(TestCase):
                     "package"])
         assertRegisteryDiscoverable(
             self,
-            lambda service: decoded_check_output(
+            lambda service: check_output(
                 ["java", "-jar", os.path.join(
                     CODE_PATH,"resolve_java/target/resolve-0.0.1.jar"),
                  service]))

--- a/functionaltests/test_webframeworks.py
+++ b/functionaltests/test_webframeworks.py
@@ -1,0 +1,85 @@
+"""
+Web framework integration tests.
+
+We want to verify:
+1. Request start interaction
+2. Response ends interaction
+3. X-MDK-CONTEXT is parsed, new session created otherwise
+4. errors cause interaction failure
+
+To test a web framework you must create a server using that has the following
+setup:
+
+1. An endpoint /context that returns the result of externalize() on the current
+   session. This verifies X-MDK-CONTEXT handling.
+2. StaticRoutes used as a discovery source with nodes service1 -> address1,
+   service2 -> address2, service2 -> service3.
+3. RecordingFailurePolicy used as the FailurePolicy.
+4. An endpoint /resolve?services=a,b,c. Each comma separated service should be
+   resolved, and the result returned as a JSON object mapping service name to a
+   list with first value being number of successes, second value being number of
+   failures recorded.
+
+
+XXXX
+Implementation ideas:
+
+For errors:
+1. Add a FailurePolicy that records failures
+2. Test suite registers known bad service with unique id that is at localhost:1, thus causing failures if connected to? or maybe just hard code a particular address as being bad and causing exception?
+
+For X-MDK-Context:
+Send query with header that causes logging.
+Send query without header that causes logging.
+
+For interaction start:
+Add StaticDiscoverySource that stores entries in memory.
+Add API for extracting nodes used in an interaction?
+"""
+
+import pathlib
+import sys
+from json import loads
+from subprocess import Popen
+
+import requests
+import pytest
+
+from utils import run_python
+
+
+WEBSERVERS_ROOT = pathlib.Path(__file__).parent / "webservers"
+URL = "http://localhost:9191"
+
+
+@pytest.fixture(scope="module",
+                params=[
+                    [sys.executable, str(WEBSERVERS_ROOT / "flaskserver.py")],
+                ])
+def webserver(request):
+    """A fixture that runs a webserver in the background on port 9191."""
+    p = Popen(request.param)
+    yield
+    p.terminate()
+    p.wait()
+
+
+def test_with_context(webserver):
+    """
+    If a X-MDK-CONTEXT header is sent to the webserver it reads it and uses the
+    encoded session.
+    """
+    context = run_python("create-context.py", output=True)
+    returned_context = requests.get(URL + "/context",
+                                    headers={"X-MDK-CONTEXT": context}).json()
+    assert loads(context.decode("utf-8"))["traceId"] == returned_context["traceId"]
+
+
+def test_without_context(webserver):
+    """
+    If no X-MDK-CONTEXT header is sent to the webserver it creates a new
+    session.
+    """
+    context = run_python("create-context.py", output=True)
+    returned_context = requests.get(URL + "/context").json()
+    assert loads(context.decode("utf-8"))["traceId"] != returned_context["traceId"]

--- a/functionaltests/test_webframeworks.py
+++ b/functionaltests/test_webframeworks.py
@@ -71,7 +71,7 @@ def test_session_with_context(webserver):
     If a X-MDK-CONTEXT header is sent to the webserver it reads it and uses the
     encoded session.
     """
-    context = run_python("create-context.py", output=True)
+    context = run_python(sys.executable, "create-context.py", output=True)
     returned_context = requests.get(URL + "/context",
                                     headers={"X-MDK-CONTEXT": context}).json()
     assert loads(context.decode("utf-8"))["traceId"] == returned_context["traceId"]
@@ -82,7 +82,7 @@ def test_session_without_context(webserver):
     If no X-MDK-CONTEXT header is sent to the webserver it creates a new
     session.
     """
-    context = run_python("create-context.py", output=True)
+    context = run_python(sys.executable, "create-context.py", output=True)
     returned_context = requests.get(URL + "/context").json()
     assert loads(context.decode("utf-8"))["traceId"] != returned_context["traceId"]
 

--- a/functionaltests/utils.py
+++ b/functionaltests/utils.py
@@ -1,19 +1,19 @@
 import os
-import sys
 from subprocess import check_call, check_output
 
 
 CODE_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "source"))
+ROOT_PATH = os.path.abspath(os.path.join(CODE_PATH, "../.."))
 
 
-def run_python(command, extra_args=(), output=False):
+def run_python(python_binary, command, extra_args=(), output=False):
     """
     Run a Python program.
 
     Returns output if output=True, in which case stderr will cause error.
     """
-    args = [sys.executable, os.path.join(CODE_PATH, command)] + list(extra_args)
+    args = [python_binary, os.path.join(CODE_PATH, command)] + list(extra_args)
     if output:
         command = check_output
     else:

--- a/functionaltests/utils.py
+++ b/functionaltests/utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from subprocess import check_call, check_output
+
+
+CODE_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "source"))
+
+
+def run_python(command, extra_args=(), output=False):
+    """
+    Run a Python program.
+
+    Returns output if output=True, in which case stderr will cause error.
+    """
+    args = [sys.executable, os.path.join(CODE_PATH, command)] + list(extra_args)
+    if output:
+        command = check_output
+    else:
+        command = check_call
+    return command(args)

--- a/functionaltests/webservers/flaskserver.py
+++ b/functionaltests/webservers/flaskserver.py
@@ -1,0 +1,20 @@
+"""
+Flask server that uses MDK's Flask integration and exposes the behavior
+expected by test_webframeworks.py.
+"""
+
+from flask import g, Flask
+
+from mdk.flask import mdk_setup
+
+app = Flask(__name__)
+
+
+@app.route("/context")
+def context():
+    return g.mdk_session.externalize()
+
+
+if __name__ == '__main__':
+    mdk_setup(app)
+    app.run(port=9191)

--- a/python/flask.py
+++ b/python/flask.py
@@ -22,7 +22,8 @@ def _on_request_started(sender, **extra):
 def _on_request_exception(sender, **extra):
     """Fail interaction when a request handlers raises an error."""
     exc = extra.get("exception", None)
-    g.mdk_session.fail_interaction(traceback.format_exc(exc))
+    g.mdk_session.fail_interaction(
+        "".join(traceback.format_exception_only(exc.__class__, exc)))
 
 def _on_request_tearing_down(sender, **extra):
     """Finish an interaction when a request is done."""

--- a/python/flask.py
+++ b/python/flask.py
@@ -1,0 +1,42 @@
+"""
+Flask integration for the MDK.
+
+This requires Flask and the blinker library.
+"""
+
+import atexit
+import traceback
+
+import mdk
+
+from flask import (
+    g, request, request_started, got_request_exception, request_tearing_down,
+)
+
+def _on_request_started(sender, **extra):
+    """Create a new MDK session at request start."""
+    g.mdk_session = sender.mdk.join(
+        request.headers.get(sender.mdk.CONTEXT_HEADER))
+    g.mdk_session.start_interaction()
+
+def _on_request_exception(sender, **extra):
+    """Fail interaction when a request handlers raises an error."""
+    exc = extra.get("exception", None)
+    g.mdk_session.fail_interaction(traceback.format_exc(exc))
+
+def _on_request_tearing_down(sender, **extra):
+    """Finish an interaction when a request is done."""
+    g.mdk_session.finish_interaction()
+    del g.mdk_session
+
+
+def mdk_setup(app):
+    """Setup MDK integration with Flask."""
+    app.mdk = mdk.start()
+    atexit.register(app.mdk.stop)
+    request_started.connect(_on_request_started, app)
+    got_request_exception.connect(_on_request_exception, app)
+    request_tearing_down.connect(_on_request_tearing_down, app)
+
+
+__all__ = ["mdk_setup"]

--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -115,6 +115,13 @@ namespace mdk_discovery {
     class StaticRoutes extends DiscoverySourceFactory {
         List<Node> _knownNodes;
 
+        static StaticRoutes parseJSON(String json_encoded) {
+            List<Node> nodes = [];
+            fromJSON(Class.get("quark.List<mdk_discovery.Node>"), nodes,
+                     json_encoded.parseJSON());
+            return new StaticRoutes(nodes);
+        }
+
         StaticRoutes(List<Node> knowNodes) {
             self._knownNodes = knowNodes;
         }

--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -88,6 +88,46 @@ namespace mdk_discovery {
         bool isRegistrar();
     }
 
+    @doc("Discovery actor for hard-coded static routes.")
+    class _StaticRoutesActor extends DiscoverySource {
+        Actor _subscriber;
+        List<Node> _knownNodes;
+
+        _StaticRoutesActor(Actor subscriber, List<Node> knownNodes) {
+            self._subscriber = subscriber;
+            self._knownNodes = knownNodes;
+        }
+
+        void onStart(MessageDispatcher dispatcher) {
+            int idx = 0;
+            while (idx < self._knownNodes.size()) {
+                dispatcher.tell(self, new NodeActive(self._knownNodes[idx]),
+                                self._subscriber);
+                idx = idx + 1;
+            }
+        }
+
+        void onMessage(Actor origin, Object message) {}
+        void onStop() {}
+    }
+
+    @doc("Create a DiscoverySource with hard-coded static routes.")
+    class StaticRoutes extends DiscoverySourceFactory {
+        List<Node> _knownNodes;
+
+        StaticRoutes(List<Node> knowNodes) {
+            self._knownNodes = knowNodes;
+        }
+
+        bool isRegistrar() {
+            return false;
+        }
+
+        DiscoverySource create(Actor subscriber, MDKRuntime runtime) {
+            return new _StaticRoutesActor(subscriber, self._knownNodes);
+        }
+    }
+
     @doc("Message sent to DiscoveryRegistrar Actor to register a node.")
     class RegisterNode {
         Node node;
@@ -202,6 +242,33 @@ namespace mdk_discovery {
 
         FailurePolicy create() {
             return new CircuitBreaker(time, threshold, retestDelay);
+        }
+    }
+
+    @doc("FailurePolicy that records failures and successes.")
+    class RecordingFailurePolicy extends FailurePolicy {
+        int successes = 0;
+        int failures = 0;
+
+        void success() {
+            self.successes = self.successes + 1;
+        }
+
+        void failure() {
+            self.failures = self.failures + 1;
+        }
+
+        bool available() {
+            return true;
+        }
+    }
+
+    @doc("Factory for FailurePolicy useful for testing.")
+    class RecordingFailurePolicyFactory extends FailurePolicyFactory {
+        RecordingFailurePolicyFactory() {}
+
+        FailurePolicy create() {
+            return new RecordingFailurePolicy();
         }
     }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -270,7 +270,12 @@ namespace mdk {
                 if (config.startsWith("synapse:path=")) {
                     result = mdk_discovery.synapse.Synapse(config.substring(13, config.size()));
                 } else {
-                    panic("Unknown MDK discovery source: " + config);
+                    if (config.startsWith("static:nodes=")) {
+                        String json = config.substring(14, config.size());
+                        result = mdk_discovery.StaticRoutes.parseJSON(json);
+                    } else {
+                        panic("Unknown MDK discovery source: " + config);
+                    }
                 }
             }
             return result;

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -271,7 +271,7 @@ namespace mdk {
                     result = mdk_discovery.synapse.Synapse(config.substring(13, config.size()));
                 } else {
                     if (config.startsWith("static:nodes=")) {
-                        String json = config.substring(14, config.size());
+                        String json = config.substring(13, config.size());
                         result = mdk_discovery.StaticRoutes.parseJSON(json);
                     } else {
                         panic("Unknown MDK discovery source: " + config);
@@ -281,12 +281,23 @@ namespace mdk {
             return result;
         }
 
+        @doc("Choose FailurePolicy based on environment variables.")
+        FailurePolicyFactory getFailurePolicy(MDKRuntime runtime) {
+            String config = runtime.getEnvVarsService()
+                .var("MDK_FAILURE_POLICY").orElseGet("");
+            if (config == "recording") {
+                return new mdk_discovery.RecordingFailurePolicyFactory();
+            } else {
+                return new CircuitBreakerFactory(runtime);
+            }
+        }
+
         MDKImpl(MDKRuntime runtime) {
             _reflection_hack = new Map<String,Object>();
             _runtime = runtime;
             if (!runtime.dependencies.hasService("failurepolicy_factory")) {
                 runtime.dependencies.registerService("failurepolicy_factory",
-                                                     new CircuitBreakerFactory(runtime));
+                                                     getFailurePolicy(runtime));
             }
             _disco = new Discovery(runtime);
             // Tracing won't work if there's no DATAWIRE_TOKEN, but will try

--- a/unittests/test_discovery.py
+++ b/unittests/test_discovery.py
@@ -9,6 +9,7 @@ from builtins import range
 from builtins import object
 
 from unittest import TestCase
+from json import dumps
 
 from hypothesis.stateful import GenericStateMachine
 from hypothesis import strategies as st
@@ -394,13 +395,30 @@ class StaticDiscoverySourceTests(TestCase):
         self.runtime = fake_runtime()
         self.disco = Discovery(self.runtime)
         self.runtime.dispatcher.startActor(self.disco)
-        self.nodes = [create_node("a", "service1"),
-                      create_node("b", "service2")]
-        self.static = StaticRoutes(self.nodes).create(self.disco, self.runtime)
-        self.runtime.dispatcher.startActor(self.static)
 
     def test_active(self):
         """The nodes the StaticRoutes was registered with are active."""
-        self.assertEqual(self.disco.knownNodes("service1"), [self.nodes[0]])
-        self.assertEqual(self.disco.knownNodes("service2"), [self.nodes[1]])
+        nodes = [create_node("a", "service1"),
+                 create_node("b", "service2")]
+        static = StaticRoutes(nodes).create(self.disco, self.runtime)
+        self.runtime.dispatcher.startActor(static)
 
+        self.assertEqual(self.disco.knownNodes("service1"), [nodes[0]])
+        self.assertEqual(self.disco.knownNodes("service2"), [nodes[1]])
+
+    def test_parseJSON(self):
+        """
+        Nodes encoded as JSON and loaded with StaticRoutes.parseJSON are registered
+        as active.
+        """
+        static = StaticRoutes.parseJSON(dumps(
+            [{"service": "service1", "address": "a", "version": "1.0"},
+             {"service": "service2", "address": "b", "version": "2.0"}]
+        )).create(self.disco, self.runtime)
+
+        self.runtime.dispatcher.startActor(static)
+
+        [node1] = self.disco.knownNodes("service1")
+        self.assertEqual((node1.address, node1.version), ("a", "1.0"))
+        [node2] = self.disco.knownNodes("service2")
+        self.assertEqual((node2.address, node2.version), ("b", "2.0"))

--- a/unittests/test_discovery.py
+++ b/unittests/test_discovery.py
@@ -17,7 +17,7 @@ from .common import fake_runtime
 
 from mdk_discovery import (
     Discovery, Node, NodeActive, NodeExpired, ReplaceCluster,
-    CircuitBreakerFactory,
+    CircuitBreakerFactory, StaticRoutes,
 )
 
 
@@ -385,3 +385,22 @@ class StatefulDiscoveryTesting(GenericStateMachine):
         self.fake.compare(self.real)
 
 StatefulDiscoveryTests = StatefulDiscoveryTesting.TestCase
+
+
+class StaticDiscoverySourceTests(TestCase):
+    """Tests for StaticDiscoverySource."""
+
+    def setUp(self):
+        self.runtime = fake_runtime()
+        self.disco = Discovery(self.runtime)
+        self.runtime.dispatcher.startActor(self.disco)
+        self.nodes = [create_node("a", "service1"),
+                      create_node("b", "service2")]
+        self.static = StaticRoutes(self.nodes).create(self.disco, self.runtime)
+        self.runtime.dispatcher.startActor(self.static)
+
+    def test_active(self):
+        """The nodes the StaticRoutes was registered with are active."""
+        self.assertEqual(self.disco.knownNodes("service1"), [self.nodes[0]])
+        self.assertEqual(self.disco.knownNodes("service2"), [self.nodes[1]])
+

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -2,7 +2,6 @@
 Tests for the MDK public API that are easier to do in Python.
 """
 from builtins import range
-from builtins import object
 from past.builtins import unicode
 
 from unittest import TestCase
@@ -14,7 +13,9 @@ from hypothesis import given, assume
 
 from mdk import MDKImpl
 from mdk_runtime import fakeRuntime
-from mdk_discovery import ReplaceCluster, NodeActive
+from mdk_discovery import (
+    ReplaceCluster, NodeActive, RecordingFailurePolicyFactory,
+)
 
 from .test_discovery import create_node
 
@@ -54,27 +55,6 @@ class MDKInitializationTestCase(TestCase):
         self.assertFalse(runtime.getWebSocketsService().fakeActors)
 
 
-class TestingFailurePolicy(object):
-    """FailurePolicy used for testing."""
-    successes = 0
-    failures = 0
-
-    def success(self):
-        self.successes += 1
-
-    def failure(self):
-        self.failures += 1
-
-    def available(self):
-        return True
-
-
-class TestingFailurePolicyFactory(object):
-    """Factory for TestingFailurePolicy."""
-    def create(self):
-        return TestingFailurePolicy()
-
-
 def add_bools(list_of_lists):
     """
     Given recursive list that can contain other lists, return tuple of that plus
@@ -99,7 +79,7 @@ class InteractionTestCase(TestCase):
         self.runtime = fakeRuntime()
         self.runtime.getEnvVarsService().set("DATAWIRE_TOKEN", "")
         self.runtime.dependencies.registerService("failurepolicy_factory",
-                                                  TestingFailurePolicyFactory())
+                                                  RecordingFailurePolicyFactory())
         self.mdk = MDKImpl(self.runtime)
         self.mdk.start()
         self.disco = self.mdk._disco

--- a/unittests/test_synapse.py
+++ b/unittests/test_synapse.py
@@ -4,7 +4,7 @@ Tests for Synapse DiscoverySource support.
 
 from __future__ import absolute_import
 
-from unittest import TestCase, SkipTest
+from unittest import TestCase
 from shutil import rmtree
 from tempfile import mkdtemp
 from json import dumps


### PR DESCRIPTION
1. Add compliance suite for web frameworks
2. Add Flask integration
3. (unrelated scope creep) Some improvements to the way tests run which are side-effect of some things I thought were necessary for item 1 and didn't turn out to be (the read_logs.py stuff).
4. (unrelated scope creep) Python 3 is used as default test runner for functional tests, and end-to-end tests run on Python 2 and 3.
