### PR TITLE
Improve consistency of MDK tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-python:
 
 .PHONY: test-python3
 test-python3: guard-token
-	virtualenv3/bin/py.test -n 4 -v --timeout=180 unittests functionaltests
+	virtualenv3/bin/py.test -n 4 -v --timeout=180 --timeout_method=thread unittests functionaltests
 
 release-minor:
 	virtualenv/bin/python scripts/release.py minor

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/bin/bash
 default:
 	echo "You can run:"
 	echo "* 'make setup' to setup the environment"
-	echo "* 'make test' to run tests (requires setup)"
+	echo "* 'make test' to run tests (requires setup and DATAWIRE_TOKEN)"
 	echo "* 'make packages' to build packages (.whl, .gem, etc.)"
 	echo "* 'make release-patch' to do a patch release (2.0.x)"
 	echo "* 'make release-minor' to do a minor release (2.x.0)"
@@ -77,6 +77,13 @@ install-mdk: packages $(wildcard javascript/datawire_mdk_express/*)
 .PHONY: test
 test: install-mdk test-python test-python3
 
+.PHONY: guard-token
+guard-token:
+	@ if [ "${DATAWIRE_TOKEN}" = "" ]; then \
+	    echo "DATAWIRE_TOKEN not set"; \
+	    exit 1; \
+	fi
+
 .PHONY: test-python
 test-python:
 	# Functional tests don't benefit from being run in another language, so
@@ -84,8 +91,8 @@ test-python:
 	virtualenv/bin/py.test -n 4 -v unittests
 
 .PHONY: test-python3
-test-python3:
-	virtualenv3/bin/py.test -n 4 -v --timeout=120 unittests functionaltests
+test-python3: guard-token
+	virtualenv3/bin/py.test -n 4 -v --timeout=180 unittests functionaltests
 
 release-minor:
 	virtualenv/bin/python scripts/release.py minor

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ clean:
 	rm -rf django110env
 	rm -fr output
 	rm -fr dist
-	rm -f quark/*.qc
+	rm -f quark/*.qc quark/tests/*.qc
 	rm -fr ~/.m2/repository/datawire_mdk
 	rm -fr ~/.m2/repository/io/datawire/mdk
 	rm -rf node_modules
+	find . -name "__pycache__" -print0 | xargs -0 rm -fr
 
 virtualenv:
 	virtualenv -p python2 virtualenv
@@ -84,7 +85,7 @@ test-python:
 
 .PHONY: test-python3
 test-python3:
-	virtualenv3/bin/py.test -n 4 -v unittests functionaltests
+	virtualenv3/bin/py.test -n 4 -v --timeout=120 unittests functionaltests
 
 release-minor:
 	virtualenv/bin/python scripts/release.py minor

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ clean:
 
 virtualenv:
 	virtualenv -p python2 virtualenv
+	virtualenv/bin/pip install -U pip
 
 .PHONY: python-dependencies
 python-dependencies: virtualenv
@@ -33,9 +34,11 @@ python-dependencies: virtualenv
 
 virtualenv3:
 	virtualenv -p python3 virtualenv3
+	virtualenv3/bin/pip install -U pip
 
 django110env:
 	virtualenv -p python3 django110env
+	django110env/bin/pip install -U pip
 
 .PHONY: python3-dependencies
 python3-dependencies: virtualenv3 django110env

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ travispy==0.3.5
 twine==1.8.1
 pytest==3.0.1
 pytest-xdist==1.15.0
+pytest-timeout==1.0.0
 future==0.15.2
 requests==2.11.1
 flask==0.11.1

--- a/functionaltests/conftest.py
+++ b/functionaltests/conftest.py
@@ -31,11 +31,13 @@ def run(filepath, language):
         maybe_sudo = []
     else:
         maybe_sudo = ["sudo"]
-    check_call(maybe_sudo +
-               ["docker", "run",
+    command = (maybe_sudo +
+               ["docker", "run", "--rm",
                 # Mount volume into container so Docker can access quark files:
                 "-v", ROOT_DIR + ":/code",] +
-                ["datawire/quark-run:" + QUARK_VERSION, "--" + language, '--verbose', docker_path])
+               ["datawire/quark-run:" + QUARK_VERSION, "--" + language, '--verbose', docker_path])
+    print(" ".join(command))
+    check_call(command)
 
 @pytest.fixture
 def quark_run(request):

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -160,6 +160,7 @@ namespace mdk_runtime {
         PromiseResolver factory;
         Actor originator;
         String url;
+        String shortURL;
         MessageDispatcher dispatcher;
         String state = "CONNECTING";
 
@@ -167,12 +168,19 @@ namespace mdk_runtime {
             self.url = url;
             self.originator = originator;
             self.factory = factory;
+
+            List<String> pieces = url.split("?");
+            self.shortURL = pieces[0];
+            if (pieces.size() > 1) {
+                self.shortURL = self.shortURL + "?" + pieces[1].substring(0, 8);
+            }
         }
 
         // Debugging
         void logTS(String message) {
             long now = Context.runtime().now();
             int tenths = (now.truncateToInt() / 100) % 100000;  // in tenths of seconds
+            if (tenths < 0) { tenths = tenths + 100000; }
             float seconds = tenths.toFloat() / 10.0;
             logger.debug(seconds.toString() + " " + message);
         }
@@ -186,7 +194,7 @@ namespace mdk_runtime {
                   ", current state " + self.state +
                   ", originator " + self.originator.toString() +
                   ", I am " + self.toString() +
-                  " [" + self.url + "]" +
+                  " [" + self.shortURL + "]" +
                   disMessage);
         }
 

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -171,9 +171,6 @@ namespace mdk_runtime {
 
         // Debugging
         void logTS(String message) {
-            if (true) {  // Disabled by default
-                return;
-            }
             long now = Context.runtime().now();
             int tenths = (now.truncateToInt() / 100) % 100000;  // in tenths of seconds
             float seconds = tenths.toFloat() / 10.0;

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -171,6 +171,9 @@ namespace mdk_runtime {
 
         // Debugging
         void logTS(String message) {
+            if (true) {  // Disabled by default
+                return;
+            }
             long now = Context.runtime().now();
             int tenths = (now.truncateToInt() / 100) % 100000;  // in tenths of seconds
             float seconds = tenths.toFloat() / 10.0;
@@ -614,6 +617,7 @@ namespace mdk_runtime {
 
     @doc("Create a MDKRuntime with the default configuration and start its actors.")
     MDKRuntime defaultRuntime() {
+        //logging.makeConfig().setLevel("DEBUG").configure();
         MDKRuntime runtime = new MDKRuntime();
         runtime.dependencies.registerService("envvar", new RealEnvVars());
         QuarkRuntimeTime timeService = new QuarkRuntimeTime();

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -614,7 +614,7 @@ namespace mdk_runtime {
 
     @doc("Create a MDKRuntime with the default configuration and start its actors.")
     MDKRuntime defaultRuntime() {
-        //logging.makeConfig().setLevel("DEBUG").configure();
+        logging.makeConfig().setLevel("DEBUG").configure();
         MDKRuntime runtime = new MDKRuntime();
         runtime.dependencies.registerService("envvar", new RealEnvVars());
         QuarkRuntimeTime timeService = new QuarkRuntimeTime();

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -14,28 +14,28 @@ import mdk_runtime.promise;
 namespace mdk_runtime {
     @doc("Trivial dependency injection setup.")
     class Dependencies {
-	Map<String,Object> _services = {};
+        Map<String,Object> _services = {};
 
-	@doc("Register a service object.")
-	void registerService(String name, Object service) {
-	    if (self._services.contains(name)) {
-		panic("Can't register service '" + name + "' twice.");
-	    }
-	    self._services[name] = service;
-	}
+        @doc("Register a service object.")
+        void registerService(String name, Object service) {
+            if (self._services.contains(name)) {
+                panic("Can't register service '" + name + "' twice.");
+            }
+            self._services[name] = service;
+        }
 
-	@doc("Look up a service by name.")
-	Object getService(String name) {
-	    if (!self._services.contains(name)) {
-		panic("Service '" + name + "' not found!");
-	    }
-	    return self._services[name];
-	}
+        @doc("Look up a service by name.")
+        Object getService(String name) {
+            if (!self._services.contains(name)) {
+                panic("Service '" + name + "' not found!");
+            }
+            return self._services[name];
+        }
 
-	@doc("Return whether the service exists.")
-	bool hasService(String name) {
-	    return self._services.contains(name);
-	}
+        @doc("Return whether the service exists.")
+        bool hasService(String name) {
+            return self._services.contains(name);
+        }
 
     }
 
@@ -48,33 +48,33 @@ namespace mdk_runtime {
     - 'websockets': A provider of mdk_runtime.WebSockets.
     """)
     class MDKRuntime {
-	Dependencies dependencies = new Dependencies();
-	MessageDispatcher dispatcher = new MessageDispatcher();
+        Dependencies dependencies = new Dependencies();
+        MessageDispatcher dispatcher = new MessageDispatcher();
 
-	@doc("Return Time service.")
-	Time getTimeService() {
-	    return ?self.dependencies.getService("time");
-	}
+        @doc("Return Time service.")
+        Time getTimeService() {
+            return ?self.dependencies.getService("time");
+        }
 
-	@doc("Return Schedule service.")
-	Actor getScheduleService() {
-	    return ?self.dependencies.getService("schedule");
-	}
+        @doc("Return Schedule service.")
+        Actor getScheduleService() {
+            return ?self.dependencies.getService("schedule");
+        }
 
-	@doc("Return WebSockets service.")
-	WebSockets getWebSocketsService() {
-	    return ?self.dependencies.getService("websockets");
-	}
+        @doc("Return WebSockets service.")
+        WebSockets getWebSocketsService() {
+            return ?self.dependencies.getService("websockets");
+        }
 
         @doc("Return File service.")
         mdk_runtime.files.FileActor getFileService() {
-	    return ?self.dependencies.getService("files");
-	}
+            return ?self.dependencies.getService("files");
+        }
 
         @doc("Return EnvironmentVariables service.")
         EnvironmentVariables getEnvVarsService() {
-	    return ?self.dependencies.getService("envvar");
-	}
+            return ?self.dependencies.getService("envvar");
+        }
 
         @doc("Stop all Actors that are started by default (i.e. files, schedule).")
         void stop() {
@@ -88,10 +88,10 @@ namespace mdk_runtime {
     Return current time.
     """)
     interface Time {
-	@doc("""
+        @doc("""
         Return the current time in seconds since the Unix epoch.
         """)
-	float time();
+        float time();
     }
 
     @doc("""
@@ -108,18 +108,18 @@ namespace mdk_runtime {
     When stopped it should close all connections.
     """)
     interface WebSockets extends Actor {
-	@doc("""
+        @doc("""
         The Promise resolves to a WSActor or WSConnectError. The originator will
         receive messages.
         """)
-	mdk_runtime.promise.Promise connect(String url, Actor originator);
+        mdk_runtime.promise.Promise connect(String url, Actor originator);
     }
 
     @doc("Connection failed.")
     class WSConnectError extends Error {
-	String toString() {
-	    return "<WSConnectionError: " + super.toString() + ">";
-	}
+        String toString() {
+            return "<WSConnectionError: " + super.toString() + ">";
+        }
     }
 
     @doc("""
@@ -133,11 +133,11 @@ namespace mdk_runtime {
 
     @doc("A message was received from the server.")
     class WSMessage {
-	String body;
+        String body;
 
-	WSMessage(String body) {
-	    self.body = body;
-	}
+        WSMessage(String body) {
+            self.body = body;
+        }
     }
 
     @doc("Tell WSActor to close the connection.")
@@ -153,20 +153,20 @@ namespace mdk_runtime {
     'DISCONNECTED'.
     """)
     class QuarkRuntimeWSActor extends WSActor, WSHandler {
-	// XXX need better story for logging; perhaps integrate MDK Session with
-	// the MessageDispatcher?
-	Logger logger = new Logger("protocol");
-	WebSocket socket;
-	PromiseResolver factory;
-	Actor originator;
-	MessageDispatcher dispatcher;
-	String state = "CONNECTING";
+        // XXX need better story for logging; perhaps integrate MDK Session with
+        // the MessageDispatcher?
+        Logger logger = new Logger("protocol");
+        WebSocket socket;
+        PromiseResolver factory;
+        Actor originator;
+        MessageDispatcher dispatcher;
+        String state = "CONNECTING";
         List<Object> incoming = [];  // FIXME: WS Messages received before actor has started
 
-	QuarkRuntimeWSActor(Actor originator, PromiseResolver factory) {
-	    self.originator = originator;
-	    self.factory = factory;
-	}
+        QuarkRuntimeWSActor(Actor originator, PromiseResolver factory) {
+            self.originator = originator;
+            self.factory = factory;
+        }
 
         // Debugging
         void logTS(String message) {
@@ -188,10 +188,10 @@ namespace mdk_runtime {
                   disMessage);
         }
 
-	// Actor
-	void onStart(MessageDispatcher dispatcher) {
+        // Actor
+        void onStart(MessageDispatcher dispatcher) {
             logPrologue("ws onStart");
-	    self.dispatcher = dispatcher;
+            self.dispatcher = dispatcher;
 
             // Send actor-model messages for incoming WS messages
             // received before this actor was started. FIXME: This
@@ -199,53 +199,53 @@ namespace mdk_runtime {
             while (self.incoming.size() > 0) {
                 self.dispatcher.tell(self, self.incoming.remove(0), self.originator);
             }
-	}
+        }
 
-	void onMessage(Actor origin, Object message) {
+        void onMessage(Actor origin, Object message) {
             logPrologue("ws onMessage (actor message)");
             logTS("   message is from " + origin.toString());
-	    if (message.getClass().id == "quark.String"
-		&& self.state == "CONNECTED") {
+            if (message.getClass().id == "quark.String"
+                && self.state == "CONNECTED") {
                 logTS("   send-ish, message is: " + message.toString());
-		self.socket.send(?message);
-		return;
-	    }
-	    if (message.getClass().id == "mdk_runtime.WSClose"
-		&& self.state == "CONNECTED") {
+                self.socket.send(?message);
+                return;
+            }
+            if (message.getClass().id == "mdk_runtime.WSClose"
+                && self.state == "CONNECTED") {
                 logTS("   close-ish, switching to DISCONNECTING state");
-		self.state = "DISCONNECTING";
-		self.socket.close();
-		return;
-	    }
+                self.state = "DISCONNECTING";
+                self.socket.close();
+                return;
+            }
             logger.warn("ws onMessage got unhandled message: " +
                         message.getClass().id + " in state " + self.state);
-	}
+        }
 
-	// WSHandler
-	void onWSConnected(WebSocket socket) {
+        // WSHandler
+        void onWSConnected(WebSocket socket) {
             logPrologue("onWSConnected");
-	    if (self.state == "ERROR") {
-		logTS("Connection event after error event!");
-		return;
-	    }
-	    self.state = "CONNECTED";
-	    self.socket = socket;
-	    self.factory.resolve(self);
-	}
+            if (self.state == "ERROR") {
+                logTS("Connection event after error event!");
+                return;
+            }
+            self.state = "CONNECTED";
+            self.socket = socket;
+            self.factory.resolve(self);
+        }
 
-	void onWSError(WebSocket socket, WSError error) {
+        void onWSError(WebSocket socket, WSError error) {
             logPrologue("onWSError");
             logTS("onWSError, reason is: " + error.toString());
-	    if (self.state == "CONNECTING") {
-		logger.error("Error connecting to WebSocket: " + error.toString());
+            if (self.state == "CONNECTING") {
+                logger.error("Error connecting to WebSocket: " + error.toString());
                 self.state = "ERROR";
-		self.factory.reject(new WSConnectError(error.toString()));
-		return;
-	    }
-	    logger.error("WebSocket error: " + error.toString());
-	}
+                self.factory.reject(new WSConnectError(error.toString()));
+                return;
+            }
+            logger.error("WebSocket error: " + error.toString());
+        }
 
-	void onWSMessage(WebSocket socket, String message) {
+        void onWSMessage(WebSocket socket, String message) {
             logPrologue("onWSMessage");
             logTS("onWSMessage, message is: " + message);
 
@@ -259,13 +259,13 @@ namespace mdk_runtime {
             } else {
                 self.dispatcher.tell(self, deliverable, self.originator);
             }
-	}
+        }
 
-	void onWSFinal(WebSocket socket) {
+        void onWSFinal(WebSocket socket) {
             logPrologue("onWSFinal");
-	    if (self.state == "DISCONNECTING" || self.state == "CONNECTED") {
-		self.state = "DISCONNECTED";
-		self.socket = null;
+            if (self.state == "DISCONNECTING" || self.state == "CONNECTED") {
+                self.state = "DISCONNECTED";
+                self.socket = null;
 
                 // FIXME: Racy race race! See onWSMessage(...) above.
                 Object deliverable = new WSClosed();
@@ -274,31 +274,31 @@ namespace mdk_runtime {
                 } else {
                     self.dispatcher.tell(self, deliverable, self.originator);
                 }
-	    }
-	}
+            }
+        }
     }
 
     @doc("""
     WebSocket that uses current Quark runtime as temporary expedient.
     """)
     class QuarkRuntimeWebSockets extends WebSockets {
-	// XXX need better story for logging; perhaps integrate MDK Session with
-	// the MessageDispatcher?
-	Logger logger = new Logger("protocol");
+        // XXX need better story for logging; perhaps integrate MDK Session with
+        // the MessageDispatcher?
+        Logger logger = new Logger("protocol");
 
-	MessageDispatcher dispatcher;
+        MessageDispatcher dispatcher;
         List<WSActor> connections = [];
 
-	mdk_runtime.promise.Promise connect(String url, Actor originator) {
-	    logger.debug(originator.toString() + "requested connection to "
-			 + url);
-	    PromiseResolver factory =  new PromiseResolver(self.dispatcher);
-	    QuarkRuntimeWSActor actor = new QuarkRuntimeWSActor(originator, factory);
+        mdk_runtime.promise.Promise connect(String url, Actor originator) {
+            logger.debug(originator.toString() + "requested connection to "
+                         + url);
+            PromiseResolver factory =  new PromiseResolver(self.dispatcher);
+            QuarkRuntimeWSActor actor = new QuarkRuntimeWSActor(originator, factory);
             connections.add(actor);
-	    self.dispatcher.startActor(actor);
-	    Context.runtime().open(url, actor);
-	    return factory.promise;
-	}
+            self.dispatcher.startActor(actor);
+            Context.runtime().open(url, actor);
+            return factory.promise;
+        }
 
         void onStart(MessageDispatcher dispatcher) {
             self.dispatcher = dispatcher;
@@ -333,20 +333,20 @@ namespace mdk_runtime {
         }
 
         void onStart(MessageDispatcher dispatcher) {
-	    self.dispatcher = dispatcher;
-	}
+            self.dispatcher = dispatcher;
+        }
 
         void onMessage(Actor origin, Object message) {
             if (message.getClass().id == "quark.String"
                 && self.state == "CONNECTED") {
-		self.sent.add(?message);
-		return;
-	    }
-	    if (message.getClass().id == "mdk_runtime.WSClose"
-		&& self.state == "CONNECTED") {
+                self.sent.add(?message);
+                return;
+            }
+            if (message.getClass().id == "mdk_runtime.WSClose"
+                && self.state == "CONNECTED") {
                 self.close();
-		return;
-	    }
+                return;
+            }
         }
 
         // Testing API:
@@ -423,19 +423,19 @@ namespace mdk_runtime {
 
         mdk_runtime.promise.Promise connect(String url, Actor originator) {
             PromiseResolver factory =  new PromiseResolver(self.dispatcher);
-	    FakeWSActor actor = new FakeWSActor(originator, factory, url);
-	    self.dispatcher.startActor(actor);
+            FakeWSActor actor = new FakeWSActor(originator, factory, url);
+            self.dispatcher.startActor(actor);
             self.fakeActors.add(actor);
-	    return factory.promise;
-	}
+            return factory.promise;
+        }
 
         FakeWSActor lastConnection() {
             return self.fakeActors[self.fakeActors.size() - 1];
         }
 
         void onStart(MessageDispatcher dispatcher) {
-	    self.dispatcher = dispatcher;
-	}
+            self.dispatcher = dispatcher;
+        }
 
         void onMessage(Actor origin, Object message) {}
     }
@@ -445,41 +445,41 @@ namespace mdk_runtime {
     seconds.
     """)
     class Schedule {
-	String event;
-	float seconds;
+        String event;
+        float seconds;
 
-	Schedule(String event, float seconds) {
-	    self.event = event;
-	    self.seconds = seconds;
-	}
+        Schedule(String event, float seconds) {
+            self.event = event;
+            self.seconds = seconds;
+        }
     }
 
     @doc("A scheduled event is now happening.")
     class Happening {
-	String event;
-	float currentTime;
+        String event;
+        float currentTime;
 
-	Happening(String event, float currentTime) {
-	    self.event = event;
-	    self.currentTime = currentTime;
-	}
+        Happening(String event, float currentTime) {
+            self.event = event;
+            self.currentTime = currentTime;
+        }
     }
 
     class _ScheduleTask extends Task {
-	QuarkRuntimeTime timeService;
-	Actor requester;
-	String event;
+        QuarkRuntimeTime timeService;
+        Actor requester;
+        String event;
 
-	_ScheduleTask(QuarkRuntimeTime timeService, Actor requester, String event) {
-	    self.timeService = timeService;
-	    self.requester = requester;
-	    self.event = event;
-	}
+        _ScheduleTask(QuarkRuntimeTime timeService, Actor requester, String event) {
+            self.timeService = timeService;
+            self.requester = requester;
+            self.event = event;
+        }
 
-	void onExecute(Runtime runtime) {
-	    timeService.dispatcher.tell(
-	        self.timeService, new Happening(self.event, self.timeService.time()), self.requester);
-	}
+        void onExecute(Runtime runtime) {
+            timeService.dispatcher.tell(
+                self.timeService, new Happening(self.event, self.timeService.time()), self.requester);
+        }
     }
 
     @doc("""
@@ -487,86 +487,86 @@ namespace mdk_runtime {
     implementation.
     """)
     class QuarkRuntimeTime extends Time, SchedulingActor {
-	MessageDispatcher dispatcher;
+        MessageDispatcher dispatcher;
         bool stopped = false;
 
-	void onStart(MessageDispatcher dispatcher) {
-	    self.dispatcher = dispatcher;
-	}
+        void onStart(MessageDispatcher dispatcher) {
+            self.dispatcher = dispatcher;
+        }
 
         void onStop() {
             self.stopped = true;
         }
 
-	void onMessage(Actor origin, Object msg) {
+        void onMessage(Actor origin, Object msg) {
             if (self.stopped) {
                 return;
             }
-	    Schedule sched = ?msg;
+            Schedule sched = ?msg;
             float seconds = sched.seconds;
             if (seconds == 0.0) {
                 // Reduce chances of reentrant scheduled event; shouldn't be
                 // necessary in non-threaded versions.
                 seconds = 0.001;
             }
-	    Context.runtime().schedule(new _ScheduleTask(self, origin, sched.event), seconds);
-	}
+            Context.runtime().schedule(new _ScheduleTask(self, origin, sched.event), seconds);
+        }
 
-	float time() {
-	    float milliseconds = Context.runtime().now().toFloat();
-	    return milliseconds / 1000.0;
-	}
+        float time() {
+            float milliseconds = Context.runtime().now().toFloat();
+            return milliseconds / 1000.0;
+        }
     }
 
     class _FakeTimeRequest {
-	Actor requester;
-	String event;
-	float happensAt;
+        Actor requester;
+        String event;
+        float happensAt;
 
-	_FakeTimeRequest(Actor requester, String event, float happensAt) {
-	    self.requester = requester;
-	    self.event = event;
-	    self.happensAt = happensAt;
-	}
+        _FakeTimeRequest(Actor requester, String event, float happensAt) {
+            self.requester = requester;
+            self.event = event;
+            self.happensAt = happensAt;
+        }
     }
 
     @doc("Testing fake.")
     class FakeTime extends Time, SchedulingActor {
-	float _now = 1000.0;
-	Map<long,_FakeTimeRequest> _scheduled = {};
-	MessageDispatcher dispatcher;
+        float _now = 1000.0;
+        Map<long,_FakeTimeRequest> _scheduled = {};
+        MessageDispatcher dispatcher;
 
-	void onStart(MessageDispatcher dispatcher) {
-	    self.dispatcher = dispatcher;
-	}
+        void onStart(MessageDispatcher dispatcher) {
+            self.dispatcher = dispatcher;
+        }
 
-	void onMessage(Actor origin, Object msg) {
-	    Schedule sched = ?msg;
-	    _scheduled[_scheduled.keys().size()] = new _FakeTimeRequest(origin, sched.event, self._now + sched.seconds);
-	}
+        void onMessage(Actor origin, Object msg) {
+            Schedule sched = ?msg;
+            _scheduled[_scheduled.keys().size()] = new _FakeTimeRequest(origin, sched.event, self._now + sched.seconds);
+        }
 
-	float time() {
-	    return self._now;
-	}
+        float time() {
+            return self._now;
+        }
 
-	@doc("Run scheduled events whose time has come.")
-	void pump() {
-	    int idx = 0;
-	    List<long> keys = self._scheduled.keys();
-	    while (idx < keys.size()) {
-		_FakeTimeRequest request = _scheduled[keys[idx]];
-		if (request.happensAt <= self._now) {
-		    self._scheduled.remove(keys[idx]);
-		    self.dispatcher.tell(self, new Happening(request.event, time()), request.requester);
-		}
-		idx = idx + 1;
-	    }
-	}
+        @doc("Run scheduled events whose time has come.")
+        void pump() {
+            int idx = 0;
+            List<long> keys = self._scheduled.keys();
+            while (idx < keys.size()) {
+                _FakeTimeRequest request = _scheduled[keys[idx]];
+                if (request.happensAt <= self._now) {
+                    self._scheduled.remove(keys[idx]);
+                    self.dispatcher.tell(self, new Happening(request.event, time()), request.requester);
+                }
+                idx = idx + 1;
+            }
+        }
 
-	@doc("Move time forward.")
-	void advance(float seconds) {
-	    self._now = self._now + seconds;
-	}
+        @doc("Move time forward.")
+        void advance(float seconds) {
+            self._now = self._now + seconds;
+        }
 
         @doc("Number of scheduled events.")
         int scheduled() {
@@ -636,7 +636,7 @@ namespace mdk_runtime {
 
     @doc("Create a MDKRuntime with the default configuration and start its actors.")
     MDKRuntime defaultRuntime() {
-	MDKRuntime runtime = new MDKRuntime();
+        MDKRuntime runtime = new MDKRuntime();
         runtime.dependencies.registerService("envvar", new RealEnvVars());
         QuarkRuntimeTime timeService = new QuarkRuntimeTime();
         QuarkRuntimeWebSockets websockets = new QuarkRuntimeWebSockets();
@@ -645,10 +645,10 @@ namespace mdk_runtime {
         runtime.dependencies.registerService("websockets", websockets);
         mdk_runtime.files.FileActor fileActor = new mdk_runtime.files.FileActorImpl(runtime);
         runtime.dependencies.registerService("files", fileActor);
-	runtime.dispatcher.startActor(timeService);
+        runtime.dispatcher.startActor(timeService);
         runtime.dispatcher.startActor(websockets);
         runtime.dispatcher.startActor(fileActor);
-	return runtime;
+        return runtime;
     }
 
     MDKRuntime fakeRuntime() {

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -493,7 +493,7 @@ namespace mdk_runtime {
             if (seconds == 0.0) {
                 // Reduce chances of reentrant scheduled event; shouldn't be
                 // necessary in non-threaded versions.
-                seconds = 0.001;
+                seconds = 0.1;
             }
             Context.runtime().schedule(new _ScheduleTask(self, origin, sched.event), seconds);
         }

--- a/quark/mdk_runtime.q
+++ b/quark/mdk_runtime.q
@@ -178,6 +178,7 @@ namespace mdk_runtime {
 
         // Debugging
         void logTS(String message) {
+            if (true) { return; }  // Ludicrous logging disabled. See also top of defaultRuntime().
             long now = Context.runtime().now();
             int tenths = (now.truncateToInt() / 100) % 100000;  // in tenths of seconds
             if (tenths < 0) { tenths = tenths + 100000; }
@@ -622,7 +623,7 @@ namespace mdk_runtime {
 
     @doc("Create a MDKRuntime with the default configuration and start its actors.")
     MDKRuntime defaultRuntime() {
-        logging.makeConfig().setLevel("DEBUG").configure();
+        //logging.makeConfig().setLevel("DEBUG").configure();
         MDKRuntime runtime = new MDKRuntime();
         runtime.dependencies.registerService("envvar", new RealEnvVars());
         QuarkRuntimeTime timeService = new QuarkRuntimeTime();


### PR DESCRIPTION
- Time out the functional tests so we can what happened
- Check for DATAWIRE_TOKEN before running functional tests
- Avoid WS race condition
- Reduce the odds of reentrant scheduled events
- Add ludicrous amounts of WS logging, disabled by default
- Untabify mdk_runtime.q -- sorry
