### PR TITLE
Combine network connections into a single one

### DIFF
--- a/quark/discovery-protocol-3.0.q
+++ b/quark/discovery-protocol-3.0.q
@@ -76,18 +76,15 @@ namespace mdk_discovery {
                 _subscriberDispatch(self, message);
             }
 
-            void onMessageFromServer(JSONObject message) {
-                String type = message["type"];
-                if (contains(["active", "discovery.protocol.Active"], type)) {
-                    Active active = new Active();
-                    fromJSON(active.getClass(), active, message);
+            void onMessageFromServer(Object message) {
+                String type = message.getClass().id;
+                if (type == "mdk_discovery.protocol.Active") {
+                    Active active = ?message;
                     onActive(active);
                     return;
                 }
-                if (contains(["expire", "discovery.protocol.Expire"],
-                             type)) {
-                    Expire expire = new Expire();
-                    fromJSON(expire.getClass(), expire, message);
+                if (type == "mdk_discovery.protocol.Expire") {
+                    Expire expire = ?message;
                     self.onExpire(expire);
                     return;
                 }

--- a/quark/discovery-protocol-3.0.q
+++ b/quark/discovery-protocol-3.0.q
@@ -15,16 +15,14 @@ namespace mdk_discovery {
         register it with the MDK.
         """)
         class DiscoClientFactory extends DiscoverySourceFactory {
-            String token;
+            WSClient wsclient;
 
-            DiscoClientFactory(String token) {
-                self.token = token;
+            DiscoClientFactory(WSClient wsclient) {
+                self.wsclient = wsclient;
             }
 
             DiscoverySource create(Actor subscriber, MDKRuntime runtime) {
-                EnvironmentVariable ddu = runtime.getEnvVarsService().var("MDK_DISCOVERY_URL");
-                String url = ddu.orElseGet("wss://discovery.datawire.io/ws/v1");
-                return new DiscoClient(subscriber, token, url, runtime);
+                return new DiscoClient(subscriber, wsclient, runtime);
             }
 
             bool isRegistrar() {

--- a/quark/discovery-protocol-3.0.q
+++ b/quark/discovery-protocol-3.0.q
@@ -52,14 +52,13 @@ namespace mdk_discovery {
             DiscoClient(Actor disco_subscriber, WSClient wsclient, MDKRuntime runtime) {
                 self._subscriber = disco_subscriber;
                 self._wsclient = wsclient;
+                self._wsclient.subscribe(self);
                 self._failurePolicyFactory = ?runtime.dependencies.getService("failurepolicy_factory");
                 self._timeService = runtime.getTimeService();
             }
 
             void onStart(MessageDispatcher dispatcher) {
                 self._dispatcher = dispatcher;
-                // Tell WSClient we want to subscribe to messages
-                self._dispatcher.tell(self, new SubscribeToWSClient(), self._wsclient);
             }
 
             void onStop() {}

--- a/quark/discovery-protocol-3.0.q
+++ b/quark/discovery-protocol-3.0.q
@@ -71,21 +71,21 @@ namespace mdk_discovery {
                     _register(register.node);
                     return;
                 }
-                subscriberDispatch(self, message);
+                _subscriberDispatch(self, message);
             }
 
             void onMessageFromServer(JSONObject message) {
                 String type = message["type"];
                 if (contains(["active", "discovery.protocol.Active"], type)) {
                     Active active = new Active();
-                    parseJSON(active.getClass(), active, message);
+                    fromJSON(active.getClass(), active, message);
                     onActive(active);
                     return;
                 }
                 if (contains(["expire", "discovery.protocol.Expire"],
                              type)) {
                     Expire expire = new Expire();
-                    parseJSON(expire.getClass(), expire, message);
+                    fromJSON(expire.getClass(), expire, message);
                     self.onExpire(expire);
                     return;
                 }
@@ -183,19 +183,6 @@ namespace mdk_discovery {
                     idx = idx + 1;
                 }
             }
-
-            void onWSMessage(String message) {
-                // Decode and dispatch incoming messages.
-                ProtocolEvent event = DiscoveryEvent.decode(message);
-                if (event == null) {
-                    // Unknown message, drop it on the floor. The decoding will
-                    // already have logged it.
-                    return;
-                }
-
-                event.dispatch(self);
-            }
-
         }
 
         /*@doc("""
@@ -216,23 +203,13 @@ namespace mdk_discovery {
         @doc("Expire a node.")
         class Expire extends Serializable {
             static String _json_type = "expire";
-            static Discriminator _discriminator = anyof();
 
             Node node;
-
-            void dispatchDiscoveryEvent(DiscoHandler handler) {
-                handler.onExpire(self);
-            }
         }
 
         @doc("Expire all nodes.")
-        class Clear extends DiscoveryEvent {
-
-            static Discriminator _discriminator = anyof(["clear", "discovery.protocol.Clear"]);
-
-            void dispatchDiscoveryEvent(DiscoHandler handler) {
-                handler.onClear(self);
-            }
+        class Clear extends Serializable {
+            static String _json_type = "clear";
         }
     }
 }

--- a/quark/discovery-protocol-3.0.q
+++ b/quark/discovery-protocol-3.0.q
@@ -61,7 +61,9 @@ namespace mdk_discovery {
                 self._dispatcher = dispatcher;
             }
 
-            void onStop() {}
+            void onStop() {
+                shutdown();
+            }
 
             void onMessage(Actor origin, Object message) {
                 String klass = message.getClass().id;

--- a/quark/mcp.q
+++ b/quark/mcp.q
@@ -1,0 +1,33 @@
+quark 1.0;
+
+include protocol-1.0.q;
+
+import mdk_protocol;
+import quark.reflect;
+
+namespace mdk_mcp_protocol {
+
+    @doc("Create a JSONParser that can read all messages to/from the MCP.")
+    JSONParser getMCPParser() {
+        JSONParser parser = new JSONParser();
+        // Open/close protocol
+        parser.register("open", Class.get("mdk_protocol.Open"));
+        parser.register("mdk.protocol.Open", Class.get("mdk_protocol.Open"));
+        parser.register("close", Class.get("mdk_protocol.Close"));
+        parser.register("mdk.protocol.Close", Class.get("mdk_protocol.Close"));
+        parser.register("discovery.protocol.Close", Class.get("mdk_protocol.Close"));
+        // Discovery protocol
+        parser.register("active", Class.get("mdk_discovery.protocol.Active"));
+        parser.register("discovery.protocol.Expire", Class.get("mdk_discovery.protocol.Expire"));
+        parser.register("expire", Class.get("mdk_discovery.protocol.Expire"));
+        parser.register("discovery.protocol.Expire", Class.get("mdk_discovery.protocol.Expire"));
+        parser.register("clear", Class.get("mdk_discovery.protocol.Clear"));
+        parser.register("discovery.protocol.Clear", Class.get("mdk_discovery.protocol.Clear"));
+        // Tracing protocol
+        parser.register("log", Class.get("mdk_tracing.protocol.LogEvent"));
+        parser.register("logack", Class.get("mdk_tracing.protocol.LogAck"));
+        parser.register("mdk_tracing.protocol.LogAckEvent", Class.get("mdk_tracing.protocol.LogAck"));
+        parser.register("subscribe", Class.get("mdk_tracing.protocol.Subscribe"));
+        return parser;
+    }
+}

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -301,8 +301,8 @@ namespace mdk {
             String disco_config = env.var("MDK_DISCOVERY_SOURCE").orElseGet("");
             if (token == "") {
                 // Another place we can get the token:
-                if (disco_config.startswith("datawire:")) {
-                    token = config.substring(9, config.size());
+                if (disco_config.startsWith("datawire:")) {
+                    token = disco_config.substring(9, disco_config.size());
                 } else {
                     return null;
                 }

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -323,7 +323,9 @@ namespace mdk {
             }
             _disco = new Discovery(runtime);
             _wsclient = getWSClient(runtime);
-            _openclose = new OpenCloseSubscriber(_wsclient);
+            if (_wsclient != null) {
+                _openclose = new OpenCloseSubscriber(_wsclient);
+            }
             EnvironmentVariables env = runtime.getEnvVarsService();
             DiscoverySourceFactory discoFactory = getDiscoveryFactory(env);
             _discoSource = discoFactory.create(_disco, runtime);
@@ -346,11 +348,13 @@ namespace mdk {
             // since that's race-condition-y, e.g. if it connects fast enough it
             // could deliver messages to disco source actor that hasn't started
             // yet.
-            _runtime.dispatcher.startActor(_wsclient);
-            _runtime.dispatcher.startActor(_openclose);
+            if (_wsclient != null) {
+                _runtime.dispatcher.startActor(_wsclient);
+                _runtime.dispatcher.startActor(_openclose);
+                _runtime.dispatcher.startActor(_tracer);
+            }
             _runtime.dispatcher.startActor(_disco);
             _runtime.dispatcher.startActor(_discoSource);
-            _runtime.dispatcher.startActor(_tracer);
         }
 
         void stop() {
@@ -359,9 +363,11 @@ namespace mdk {
             // may wish to send some unregistration messages:
             _runtime.dispatcher.stopActor(_discoSource);
             _runtime.dispatcher.stopActor(_disco);
-            _runtime.dispatcher.stopActor(_tracer);
-            _runtime.dispatcher.stopActor(_openclose);
-            _runtime.dispatcher.stopActor(_wsclient);
+            if (_wsclient != null) {
+                _runtime.dispatcher.stopActor(_tracer);
+                _runtime.dispatcher.stopActor(_openclose);
+                _runtime.dispatcher.stopActor(_wsclient);
+            }
             _runtime.stop();
         }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -312,7 +312,7 @@ namespace mdk {
             }
 
             EnvironmentVariable ddu = env.var("MDK_MCP_URL");
-            String url = ddu.orElseGet("wss://discovery.datawire.io/ws/v1");
+            String url = ddu.orElseGet("wss://mcp.datawire.io/rtp");
             return new WSClient(runtime, getMCPParser(), url, token);
         }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -9,6 +9,7 @@ include util-1.0.q;
 include introspection-1.0.q;
 include discovery-3.0.q;
 include tracing-2.0.q;
+include mcp.q;
 
 import mdk_discovery;
 import mdk_tracing;
@@ -16,6 +17,7 @@ import mdk_introspection;
 import mdk_util;
 import mdk_runtime;
 import quark.concurrent;
+import mdk_mcp_protocol;
 import mdk_runtime.promise;
 
 @doc("Microservices Development Kit -- obtain a reference using MDK.init()")
@@ -311,7 +313,7 @@ namespace mdk {
 
             EnvironmentVariable ddu = env.var("MDK_MCP_URL");
             String url = ddu.orElseGet("wss://discovery.datawire.io/ws/v1");
-            return new WSClient(runtime, url, token);
+            return new WSClient(runtime, getMCPParser(), url, token);
         }
 
         MDKImpl(MDKRuntime runtime) {

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -9,7 +9,7 @@ include util-1.0.q;
 include introspection-1.0.q;
 include discovery-3.0.q;
 include tracing-2.0.q;
-include mcp.q;
+include rtp.q;
 
 import mdk_discovery;
 import mdk_tracing;
@@ -17,7 +17,7 @@ import mdk_introspection;
 import mdk_util;
 import mdk_runtime;
 import quark.concurrent;
-import mdk_mcp_protocol;
+import mdk_rtp;
 import mdk_runtime.promise;
 
 @doc("Microservices Development Kit -- obtain a reference using MDK.init()")
@@ -311,9 +311,9 @@ namespace mdk {
                 }
             }
 
-            EnvironmentVariable ddu = env.var("MDK_MCP_URL");
+            EnvironmentVariable ddu = env.var("MDK_SERVER_URL");
             String url = ddu.orElseGet("wss://mcp.datawire.io/rtp");
-            return new WSClient(runtime, getMCPParser(), url, token);
+            return new WSClient(runtime, getRTPParser(), url, token);
         }
 
         MDKImpl(MDKRuntime runtime) {

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -329,9 +329,7 @@ namespace mdk {
                 runtime.dependencies.registerService("discovery_registrar", _discoSource);
             }
             if (_wsclient != null) {
-                String tracingQueryURL = _get(env, "MDK_TRACING_API_URL", "https://tracing.datawire.io/api/v1/logs");
                 _tracer = Tracer(runtime, _wsclient);
-                _tracer.queryURL = tracingQueryURL;
                 _tracer.initContext();
             }
         }

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -386,7 +386,6 @@ namespace mdk_protocol {
         float tick = 1.0;
 
         WSActor sock = null;
-        String sockUrl = null;
 
         long lastConnectAttempt = 0L;
 
@@ -525,20 +524,15 @@ namespace mdk_protocol {
         }
 
         void doOpen() {
-            open(url());
             lastConnectAttempt = (self.timeService.time()*1000.0).round();
-        }
-
-        void open(String url) {
-            sockUrl = url;
-            String tok = token();
-            if (tok != null) {
-                url = url + "?token=" + tok;
+            String sockUrl = url;
+            if (token != null) {
+                sockUrl = sockUrl + "?token=" + token;
             }
 
-            logger.info("opening " + sockUrl);
+            logger.info("opening " + url);
 
-            self.websockets.connect(url, self)
+            self.websockets.connect(sockUrl, self)
                 .andEither(bind(self, "onWSConnected", []),
                            bind(self, "onWSError", []));
         }
@@ -564,7 +558,7 @@ namespace mdk_protocol {
         void onWSConnected(WSActor socket) {
             // Whenever we (re)connect, notify the server of any
             // nodes we have registered.
-            logger.info("connected to " + sockUrl + " via " + socket.toString());
+            logger.info("connected to " + url + " via " + socket.toString());
 
             reconnectDelay = firstDelay;
             sock = socket;
@@ -583,7 +577,7 @@ namespace mdk_protocol {
         }
 
         void onWSClosed() {
-            logger.info("closed " + sockUrl);
+            logger.info("closed " + url);
             sock = null;
         }
     }

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -399,6 +399,8 @@ namespace mdk_protocol {
             self._dispatcher.tell(self, new Open().encode(), websocket);
         }
 
+        void onPump() {}
+
         // WebSocket message handlers:
         void onOpen() {
             // Should assert version here ...

--- a/quark/rtp.q
+++ b/quark/rtp.q
@@ -5,10 +5,10 @@ include protocol-1.0.q;
 import mdk_protocol;
 import quark.reflect;
 
-namespace mdk_mcp_protocol {
+namespace mdk_rtp {
 
     @doc("Create a JSONParser that can read all messages to/from the MCP.")
-    JSONParser getMCPParser() {
+    JSONParser getRTPParser() {
         JSONParser parser = new JSONParser();
         // Open/close protocol
         parser.register("open", Class.get("mdk_protocol.Open"));

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -82,7 +82,7 @@ class TracingTest {
     }
 
     Tracer newTracer(String url) {
-        new Tracer(runtime, new WSClient(runtime, url, "the_token"));
+        return new Tracer(runtime, new WSClient(runtime, url, "the_token"));
     }
 
     FakeWSActor startTracer(Tracer tracer) {
@@ -223,6 +223,7 @@ class DiscoveryTest {
     Discovery createDisco() {
         Discovery disco = new Discovery(runtime);
         WSClient wsclient = new WSClient(runtime, "http://url/", "");
+        runtime.dispatcher.startActor(wsclient);
         self.client = ?new mdk_discovery.protocol.DiscoClientFactory(wsclient).create(disco, self.runtime);
         runtime.dependencies.registerService("discovery_registrar", self.client);
         return disco;

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -13,7 +13,7 @@ import mdk_tracing;
 import mdk_tracing.protocol;
 import mdk_runtime;
 import mdk_discovery;
-import mdk_mcp_protocol;
+import mdk_rtp;
 
 void main(List<String> args) {
     test.run(args);
@@ -82,7 +82,7 @@ class TracingTest {
     }
 
     Tracer newTracer(String url) {
-        return new Tracer(runtime, new WSClient(runtime, getMCPParser(), url, "the_token"));
+        return new Tracer(runtime, new WSClient(runtime, getRTPParser(), url, "the_token"));
     }
 
     FakeWSActor startTracer(Tracer tracer) {
@@ -191,7 +191,7 @@ class DiscoveryTest {
 
     Discovery createDisco() {
         Discovery disco = new Discovery(runtime);
-        WSClient wsclient = new WSClient(runtime, getMCPParser(), "http://url/", "");
+        WSClient wsclient = new WSClient(runtime, getRTPParser(), "http://url/", "");
         OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient);
         runtime.dispatcher.startActor(wsclient);
         runtime.dispatcher.startActor(openclose);

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -13,6 +13,7 @@ import mdk_tracing;
 import mdk_tracing.protocol;
 import mdk_runtime;
 import mdk_discovery;
+import mdk_mcp_protocol;
 
 void main(List<String> args) {
     test.run(args);
@@ -81,7 +82,7 @@ class TracingTest {
     }
 
     Tracer newTracer(String url) {
-        return new Tracer(runtime, new WSClient(runtime, url, "the_token"));
+        return new Tracer(runtime, new WSClient(runtime, getMCPParser(), url, "the_token"));
     }
 
     FakeWSActor startTracer(Tracer tracer) {
@@ -190,7 +191,7 @@ class DiscoveryTest {
 
     Discovery createDisco() {
         Discovery disco = new Discovery(runtime);
-        WSClient wsclient = new WSClient(runtime, "http://url/", "");
+        WSClient wsclient = new WSClient(runtime, getMCPParser(), "http://url/", "");
         OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient);
         runtime.dispatcher.startActor(wsclient);
         runtime.dispatcher.startActor(openclose);

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -309,7 +309,7 @@ namespace mdk_tracing {
             void onStop() {}
 
             void onMessage(Actor origin, Object message) {
-                subscriberDispatch(self, message);
+                _subscriberDispatch(self, message);
             }
 
             void onWSConnected(Actor websock) {
@@ -356,14 +356,14 @@ namespace mdk_tracing {
                 String type = message["type"];
                 if (type == "log") {
                     LogEvent event = new LogEvent();
-                    parseJSON(event.getClass(), event, message);
+                    fromJSON(event.getClass(), event, message);
                     onLogEvent(event);
                     return;
                 }
                 if (contains(["logack", "mdk_tracing.protocol.LogAckEvent"],
                              type)) {
                     LogAck ack = new LogAck();
-                    parseJSON(ack.getClass(), ack, message);
+                    fromJSON(ack.getClass(), ack, message);
                     self.onLogAck(ack);
                     return;
                 }

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -4,7 +4,7 @@ package datawire_mdk_tracing 2.0.15;
 
 include protocol-1.0.q;
 include introspection-1.0.q;
-include mcp.q;
+include rtp.q;
 
 import mdk_runtime.actors;
 import mdk_protocol;
@@ -68,7 +68,7 @@ namespace mdk_tracing {
 
         static Tracer withURLAndToken(String url, String token) {
             MDKRuntime runtime = defaultRuntime();
-            WSClient wsclient = new WSClient(runtime, mdk_mcp_protocol.getMCPParser(), url, token);
+            WSClient wsclient = new WSClient(runtime, mdk_rtp.getRTPParser(), url, token);
             runtime.dispatcher.startActor(wsclient);
             Tracer newTracer = new Tracer(runtime, wsclient);
             runtime.dispatcher.startActor(newTracer);

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -337,6 +337,7 @@ namespace mdk_tracing {
             TracingClient(Tracer tracer, WSClient wsclient) {
                 _tracer = tracer;
                 _wsclient = wsclient;
+                wsclient.subscribe(self);
             }
 
             @doc("Attach a subscriber that will receive results of queries.")
@@ -348,8 +349,6 @@ namespace mdk_tracing {
 
             void onStart(MessageDispatcher dispatcher) {
                 self._dispatcher = dispatcher;
-                // Tell WSClient we want to subscribe to messages
-                self._dispatcher.tell(self, new SubscribeToWSClient(), self._wsclient);
             }
 
             void onStop() {}

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -82,6 +82,8 @@ namespace mdk_tracing {
             runtime.dispatcher.stopActor(_client);
         }
 
+        void onMessage(Actor origin, Object mesage) {}
+
         void initContext() {
             // Implicitly creates a span for you.
             _context.setValue(new SharedContext());

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -306,7 +306,7 @@ namespace mdk_tracing {
 
         }
 
-        class TracingClient extends TracingHandler {
+        class TracingClient extends Actor, TracingHandler {
 
             Tracer _tracer;
             bool _started = false;
@@ -359,7 +359,7 @@ namespace mdk_tracing {
                 // WSClient has connected to the server:
                 if (klass == "mdk_protocol.WSConnected") {
                     WSConnected connected = ?message;
-                    self._sock = message.websock;
+                    self._sock = connected.websock;
                     onConnect();
                 }
                 // The WSClient is telling us we can send periodic messages:
@@ -386,7 +386,7 @@ namespace mdk_tracing {
                 }
                 _debug("Starting up! with connection " + self._sock.toString());
                 if (_handler != null) {
-                    self.dispatcher.tell(self, new Subscribe().encode(), self._sock);
+                    self._dispatcher.tell(self, new Subscribe().encode(), self._sock);
                 }
                 _mutex.release();
             }
@@ -405,7 +405,7 @@ namespace mdk_tracing {
                         _lastSyncTime = evt.timestamp;
                         debugSuffix = " with sync set";
                     }
-                    self.dispatcher.tell(self, evt.encode(), self._sock);
+                    self._dispatcher.tell(self, evt.encode(), self._sock);
                     evt.sync = 0;
                     _sent = _sent + 1;
                     _debug("sent #" + evt.sequence.toString() + debugSuffix +

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -77,7 +77,7 @@ class InteractionTestCase(TestCase):
         """Initialize an empty environment."""
         # Initialize runtime and MDK:
         self.runtime = fakeRuntime()
-        self.runtime.getEnvVarsService().set("DATAWIRE_TOKEN", "")
+        self.runtime.getEnvVarsService().set("DATAWIRE_TOKEN", "somevalue")
         self.runtime.dependencies.registerService("failurepolicy_factory",
                                                   RecordingFailurePolicyFactory())
         self.mdk = MDKImpl(self.runtime)


### PR DESCRIPTION
Switch from multiple connections to different WebSocket servers to a single connection, in preparation for a world where we have just MCP instead of tracing and discovery as separate things.

Can't merge (or to be more accurate, can't release) until new single connection MCP is deployed and old URLs are pointed at it.
