### PR TITLE
Loosely coupled traces, kinda.

### DIFF
--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -106,7 +106,7 @@ namespace mdk {
         Session session();
 
         @doc("""
-             Create a new Session and join it to an existing distributed trace.
+             Create a new Session and join it to an existing distributed sesion.
 
              This should only ever be done once per an encoded context. That
              means you should only use it for RPC or similar one-off calls. If
@@ -117,9 +117,8 @@ namespace mdk {
         Session join(String encodedContext);
 
         @doc("""
-             Create a new Session, recording that it is the child of an existing
-             distributed trace. All properties of the original session will be
-             inherited, e.g. timeouts and overrides.
+             Create a new Session. All properties will of the given encoded
+             distributed session be inherited, e.g. timeouts and overrides.
 
              This is intended for use for encoded context received via a
              broadcast medium (pub/sub, message queues with multiple readers,
@@ -453,10 +452,9 @@ namespace mdk {
             SessionImpl session = ?self.session();
             SharedContext parent = SharedContext.decode(encodedContext);
             session._context.properties = parent.properties;
-            session.set("parent_trace_id", parent.traceId);
-            session.set("parent_clock_level",
-                        new ListUtil<int>().slice(parent.clock.clocks, 0,
-                                                  parent.clock.clocks.size()));
+            session.info("mdk",
+                         "This session is a child of trace " + parent.traceId + " " +
+                         parent.clock.clocks.toString());
             return session;
         }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -458,7 +458,7 @@ namespace mdk {
                 session._context.properties.remove("timeout");
             }
             session.info("mdk",
-                         "This session is a child of trace " + parent.traceId + " " +
+                         "This session is derived from trace " + parent.traceId + " " +
                          parent.clock.clocks.toString());
             return session;
         }

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -118,7 +118,8 @@ namespace mdk {
 
         @doc("""
              Create a new Session, recording that it is the child of an existing
-             distributed trace.
+             distributed trace. All properties of the original session will be
+             inherited, e.g. timeouts and overrides.
 
              This is intended for use for encoded context received via a
              broadcast medium (pub/sub, message queues with multiple readers,
@@ -448,9 +449,10 @@ namespace mdk {
             return session;
         }
 
-        Session child_session(String encodedContext) {
+        Session childSession(String encodedContext) {
             SessionImpl session = ?self.session();
             SharedContext parent = SharedContext.decode(encodedContext);
+            session._context.properties = parent.properties;
             session.set("parent_trace_id", parent.traceId);
             session.set("parent_clock_level",
                         new ListUtil<int>().slice(parent.clock.clocks, 0,

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -374,11 +374,8 @@ class SessionCreationTests(TestCase):
         session._context.tick()
         session._context.tick()
         session._context.tick()
-        expected_clock = session._context.clock.clocks[:]
         session2 = self.mdk.childSession(session.externalize())
         self.assertNotEqual(session._context.traceId,
                             session2._context.traceId)
-        self.assertSessionHas(session2, session2._context.traceId, [0],
-                              parent_trace_id=session._context.traceId,
-                              parent_clock_level=expected_clock,
+        self.assertSessionHas(session2, session2._context.traceId, [1],
                               other=123)

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -367,15 +367,18 @@ class SessionCreationTests(TestCase):
     def test_childSession(self):
         """
         A child session has a new trace ID and clock level, but knows about the
-        parent session's trace ID and clock level and inherits other properties.
+        parent session's trace ID and clock level and inherits properties other
+        than timeout.
         """
         session = self.mdk.session()
         session.set("other", 123)
         session._context.tick()
         session._context.tick()
         session._context.tick()
-        session2 = self.mdk.childSession(session.externalize())
+        session.setTimeout(13.0)
+        session2 = self.mdk.derive(session.externalize())
         self.assertNotEqual(session._context.traceId,
                             session2._context.traceId)
+        self.assertEqual(session2.getRemainingTime(), None)
         self.assertSessionHas(session2, session2._context.traceId, [1],
                               other=123)


### PR DESCRIPTION
@rhs might want a better name than `child_session` to indicate loose coupling.
