### PR TITLE
Fix version matching semantics for numbers > 9

### DIFF
--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -58,6 +58,14 @@ namespace mdk {
          process, and one instance of the Session object per
          thread/channel/request depending on how the MDK is integrated
          and used within the application framework of choice.
+
+         A note on versions: service versions indicate API compatibility, not
+         releases of the underlying code. They should be in the form
+         '<major>.<minor>', e.g. '2.11'. Major versions indicates
+         incompatibility: '1.0' is incompatible with '2.11'. Minor versions
+         indicate backwards compatibility with new features: a client that wants
+         version '1.1' can talk to version '1.1' and '1.2' but not to version
+         '1.0'.
          """)
     interface MDK {
 

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -499,24 +499,3 @@ class DiscoveryTest {
     }
 
 }
-
-class UtilTest {
-
-    void testVersionMatch() {
-        checkEqual(true, versionMatch("1", "1.0.0"));
-        checkEqual(true, versionMatch("1.0", "1.0.0"));
-        checkEqual(true, versionMatch("1.0.0", "1.0.0"));
-        checkEqual(true, versionMatch("1.0.0", "1.0"));
-        checkEqual(true, versionMatch("1.0.0", "1"));
-
-        checkEqual(true, versionMatch("1.0", "1.1"));
-        checkEqual(true, versionMatch("1.0", "1.1.0"));
-        checkEqual(true, versionMatch("1.1", "1.1"));
-        checkEqual(true, versionMatch("1.1", "1.1.0"));
-
-        checkEqual(false, versionMatch("1.2", "1.1.0"));
-        checkEqual(false, versionMatch("2.0", "1.1.0"));
-        checkEqual(false, versionMatch("1.3", "1.2"));
-    }
-
-}

--- a/quark/util-1.0.q
+++ b/quark/util-1.0.q
@@ -74,29 +74,27 @@ namespace mdk_util {
         if (requested == null) {
             return true;
         }
-
         List<String> reqparts = requested.split(".");
         List<String> actparts = actual.split(".");
-        extend(reqparts, "0", 3);
-        extend(actparts, "0", 3);
+        extend(reqparts, "0", 2);
+        extend(actparts, "0", 2);
 
-        // major must be equal
-        if (reqparts[0] != actparts[0]) {
+        int reqmajor = reqparts[0].parseInt().getValue();
+        int actmajor = actparts[0].parseInt().getValue();
+        int reqminor = reqparts[1].parseInt().getValue();
+        int actminor = actparts[1].parseInt().getValue();
+
+        // major must be equal since it's complete incompatibility
+        if (reqmajor != actmajor) {
             return false;
         }
 
-        // if minor is greater than we want that's ok
-        if (actparts[1] > reqparts[1]) {
+        // minor implies backwards compatibility
+        if (actminor >= reqminor) {
             return true;
         }
 
-        // if minor is less than we want, that's not ok
-        if (actparts[1] < reqparts[1]) {
-            return false;
-        }
-
-        // when minor is equal, we check the bug fix
-        return actparts[2] >= reqparts[2];
+        return false;
     }
 
 }

--- a/unittests/test_util.py
+++ b/unittests/test_util.py
@@ -1,0 +1,70 @@
+"""
+Tests for utilities.
+"""
+
+from hypothesis import strategies as st
+from hypothesis import given, assume
+
+from mdk_util import versionMatch
+
+
+positive_ints = st.integers(min_value=0, max_value=10000)
+major = st.tuples(positive_ints)
+major_minor = st.tuples(positive_ints, positive_ints)
+major_minor_patch = st.tuples(positive_ints, positive_ints, positive_ints)
+
+
+def match(version_tuple1, version_tuple2):
+    return versionMatch(_join(version_tuple1), _join(version_tuple2))
+
+def _join(ints):
+    return ".".join(str(i) for i in ints)
+
+@given(major_minor, major_minor)
+def test_differentMajor(version1, version2):
+    """
+    Different major versions never match.
+    """
+    assume(version1[0] != version2[0])
+    assert not match(version1, version2)
+    assert not match(version1[:1], version2)
+    assert not match(version1, version2[:1])
+    assert not match(version1[:1], version2[:1])
+
+
+@given(major_minor, positive_ints)
+def test_smallerMinor(version, minor_increment):
+    """
+    A requested version that is smaller or equal in minor increment than the
+    actual version will match.
+    """
+    larger_version = (version[0], version[1] + minor_increment)
+    assert match(version, larger_version)
+    assert match(version[:1], larger_version)
+    # Patch support only for backwards compat:
+    assert match(version + (1,), larger_version)
+    assert match(version, larger_version + (1,))
+
+
+@given(major_minor, st.integers(min_value=1, max_value=100))
+def test_largerMinor(version, minor_increment):
+    """
+    A requested version that is larger in minor increment than the actual
+    version will not match.
+    """
+    larger_version = (version[0], version[1] + minor_increment)
+    assert not match(larger_version, version)
+    assert not match(larger_version, version[:1])
+    # Patch support only for backwards compat:
+    assert not match(larger_version, version + (1,))
+    assert not match(larger_version + (1,), version)
+
+
+@given(major_minor_patch)
+def test_patchIgnored(version):
+    """
+    The patch part of version is ignored.
+    """
+    assert match(version, version[:2] + (0,))
+    assert match(version[:2] + (0,), version)
+


### PR DESCRIPTION
 (e.g. 1.10 should be > 1.2) and make semantics match new design.
