### PR TITLE
Flask logging integration

### DIFF
--- a/functionaltests/webclients/request.js
+++ b/functionaltests/webclients/request.js
@@ -13,7 +13,8 @@ mdkSession.setDeadline(1.0);
 
 var requestMDK = mdk_request.forMDKSession(mdkSession);
 requestMDK(process.argv[2], function (error, response, body) {
-    if (error !== null && error.code === 'ETIMEDOUT') {
+    if (error !== null && (error.code === 'ETIMEDOUT' ||
+                           error.code === 'ESOCKETTIMEDOUT')) {
         process.exit(123);
     } else {
         process.exit(0);

--- a/python/flask.py
+++ b/python/flask.py
@@ -4,6 +4,8 @@ Flask integration for the MDK.
 This requires Flask and the blinker library.
 """
 
+from __future__ import absolute_import
+
 import atexit
 import traceback
 

--- a/python/flask.py
+++ b/python/flask.py
@@ -7,11 +7,13 @@ This requires Flask and the blinker library.
 import atexit
 import traceback
 
-import mdk
+from mdk import start
+from .logging import MDKHandler
 
 from flask import (
     g, request, request_started, got_request_exception, request_tearing_down,
 )
+
 
 def _on_request_started(sender, **extra):
     """Create a new MDK session at request start."""
@@ -31,22 +33,44 @@ def _on_request_tearing_down(sender, **extra):
     del g.mdk_session
 
 
-def mdk_setup(app, timeout=None):
-    """Setup MDK integration with Flask.
+def mdk_setup(app, timeout=None, mdk=None):
+    """
+    Setup MDK integration with Flask.
 
     :param app: A Flask application instance.
     :param timeout: Default timeout in seconds to set for the MDK session.
+    :param mdk: An optional ``mdk.MDK`` instance to use instead of creating a
+        new one. It will not be started or stopped.
 
     :return: The ``mdk.MDK`` instance.
     """
-    app.mdk = mdk.start()
+    if mdk is None:
+        app.mdk = start()
+        atexit.register(app.mdk.stop)
+    else:
+        app.mdk = mdk
     if timeout is not None:
         app.mdk.setDefaultDeadline(timeout)
-    atexit.register(app.mdk.stop)
     request_started.connect(_on_request_started, app)
     got_request_exception.connect(_on_request_exception, app)
     request_tearing_down.connect(_on_request_tearing_down, app)
     return app.mdk
 
 
-__all__ = ["mdk_setup"]
+class MDKLoggingHandler(MDKHandler):
+    """
+    ``logging.Handler`` that routes logs to MDK and extracts MDK session from
+    the Flask request.
+    """
+    def __init__(self, mdk):
+        """
+        :param mdk: A ``mdk.MDK`` instance.
+        """
+        def get_session():
+            if not g:
+                return None
+            return getattr(g, "mdk_session", None)
+        MDKHandler.__init__(self, mdk, get_session)
+
+
+__all__ = ["mdk_setup", "MDKLoggingHandler"]

--- a/python/logging.py
+++ b/python/logging.py
@@ -10,11 +10,14 @@ from logging import StreamHandler
 class MDKHandler(StreamHandler):
     """Hand log messages to an MDK Session."""
 
-    def __init__(self, get_session):
+    def __init__(self, mdk, get_session):
         """
-        :param get_session: Unary callable that returns the current MDK Session.
+        :param mdk: A ``mdk.MDK`` instance.
+        :param get_session: Unary callable that returns the current MDK Session, or
+            ``None``, in which case a default Session will be used.
         """
         StreamHandler.__init__(self)
+        self._default_session = mdk.session()
         self._get_session = get_session
 
     def emit(self, record):
@@ -22,4 +25,6 @@ class MDKHandler(StreamHandler):
         if level == "WARNING":
             level = "WARN"
         session = self._get_session()
+        if session is None:
+            session = self._default_session
         getattr(session, level.lower())(record.name, self.format(record))

--- a/python/logging.py
+++ b/python/logging.py
@@ -1,0 +1,25 @@
+"""
+Python standard library ``logging`` support for MDK.
+"""
+
+from __future__ import absolute_import
+
+from logging import StreamHandler
+
+
+class MDKHandler(StreamHandler):
+    """Hand log messages to an MDK Session."""
+
+    def __init__(self, get_session):
+        """
+        :param get_session: Unary callable that returns the current MDK Session.
+        """
+        StreamHandler.__init__(self)
+        self._get_session = get_session
+
+    def emit(self, record):
+        level = record.levelname
+        if level == "WARNING":
+            level = "WARN"
+        session = self._get_session()
+        getattr(session, level.lower())(record.name, self.format(record))

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -430,7 +430,6 @@ namespace mdk {
             }
             if (_wsclient != null) {
                 _tracer = Tracer(runtime, _wsclient);
-                _tracer.initContext();
                 _metrics = new MetricsClient(_wsclient);
             }
         }
@@ -645,8 +644,7 @@ namespace mdk {
                     return;
                 }
                 _inLogging.setValue(true);
-                _mdk._tracer.setContext(_context);
-                _mdk._tracer.log(_mdk.procUUID, level, category, text);
+                _mdk._tracer.log(_context, _mdk.procUUID, level, category, text);
                 _inLogging.setValue(false);
             }
         }

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -786,7 +786,9 @@ namespace mdk {
                 report.addNode(node, true);
                 idx = idx + 1;
             }
-            _mdk._metrics.sendInteraction(report);
+            if (_mdk._metrics != null) {
+                _mdk._metrics.sendInteraction(report);
+            }
         }
 
         void interact(UnaryCallable cmd) {

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -415,6 +415,9 @@ namespace mdk {
                 runtime.dependencies.registerService("failurepolicy_factory",
                                                      getFailurePolicy(runtime));
             }
+            if (runtime.dependencies.hasService("tracer")) {
+                _tracer = ?_runtime.dependencies.getService("tracer");
+            }
             _disco = new Discovery(runtime);
             _wsclient = getWSClient(runtime);
             // Make sure we register OpenCloseSubscriber first so that Open
@@ -429,7 +432,9 @@ namespace mdk {
                 runtime.dependencies.registerService("discovery_registrar", _discoSource);
             }
             if (_wsclient != null) {
-                _tracer = Tracer(runtime, _wsclient);
+                if (_tracer == null) {
+                    _tracer = Tracer(runtime, _wsclient);
+                }
                 _metrics = new MetricsClient(_wsclient);
             }
         }

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -92,8 +92,8 @@ class TracingTest {
     FakeWSActor startTracer(Tracer tracer) {
         runtime.dispatcher.startActor(tracer._client._wsclient);
         runtime.dispatcher.startActor(tracer);
-        tracer.initContext();
-        tracer.log("procUUID", "DEBUG", "blah", "testing...");
+        SharedContext ctx = new SharedContext();
+        tracer.log(ctx, "procUUID", "DEBUG", "blah", "testing...");
         self.pump();
         FakeWSActor sev = expectSocket(self.runtime, tracer._client._wsclient.url + "?token=" + tracer._client._wsclient.token);
         if (sev == null) {

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -41,18 +41,10 @@ something like
 
 namespace mdk_tracing {
 
-    class SharedContextInitializer extends TLSInitializer<SharedContext> {
-        SharedContext getValue() {
-            return null;
-            // return new SharedContext();
-        }
-    }
-
     class Tracer extends Actor {
         Logger logger = new Logger("MDK Tracer");
         long lastPoll = 0L;
 
-        TLS<SharedContext> _context = new TLS<SharedContext>(new SharedContextInitializer());
         protocol.TracingClient _client;
         MDKRuntime runtime;
 
@@ -85,40 +77,9 @@ namespace mdk_tracing {
 
         void onMessage(Actor origin, Object mesage) {}
 
-        void initContext() {
-            // Implicitly creates a span for you.
-            _context.setValue(new SharedContext());
-        }
-
-        void joinContext(SharedContext context) {
-            _context.setValue(context.start_span());
-            // Always open a new span when joining a context.
-        }
-
-        void joinEncodedContext(String encodedContext) {
-            SharedContext newContext = SharedContext.decode(encodedContext);
-            self.joinContext(newContext);
-        }
-
-        SharedContext getContext() {
-            return _context.getValue();
-        }
-
-        void setContext(SharedContext ctx) {
-            _context.setValue(ctx);
-        }
-
-        void start_span() {
-            _context.setValue(self.getContext().start_span());
-        }
-
-        void finish_span() {
-            _context.setValue(self.getContext().finish_span());
-        }
-
         @doc("Send a log message to the server.")
-        void log(String procUUID, String level, String category, String text) {
-            SharedContext ctx = self.getContext();
+            void log(SharedContext ctx, String procUUID, String level,
+                     String category, String text) {
             ctx.tick();
             logger.trace("CTX " + ctx.toString());
 

--- a/unittests/test_python.py
+++ b/unittests/test_python.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for Python-specific code.
+"""
+
+import logging
+from unittest import TestCase
+
+from mdk_tracing import FakeTracer
+from mdk_runtime import fakeRuntime
+from mdk import MDKImpl
+from mdk.logging import MDKHandler
+
+
+def create_mdk():
+    """Create an MDK with a FakeTracer.
+
+    Returns (mdk, fake_tracer).
+    """
+    runtime = fakeRuntime()
+    tracer = FakeTracer()
+    runtime.dependencies.registerService("tracer", tracer)
+    runtime.getEnvVarsService().set("MDK_DISCOVERY_SOURCE", "static:nodes={}")
+    mdk = MDKImpl(runtime)
+    mdk.start()
+    return mdk, tracer
+
+
+class LoggingTests(TestCase):
+    """Tests for stdlib-logging integration."""
+
+    def test_logPassthrough(self):
+        """If MDKHandler is used, logging via stdlib is passed to MDK."""
+        logger = logging.Logger("mylog")
+        logger.setLevel(logging.DEBUG)
+        mdk, tracer = create_mdk()
+        session = mdk.session()
+        session.trace("DEBUG")
+        logger.addHandler(MDKHandler(lambda: session))
+
+        logger.debug("debugz")
+        logger.info("infoz")
+        logger.warning("warnz")
+        logger.error("errorz")
+        logger.critical("criticalz")
+
+        self.assertEqual(
+            tracer.messages,
+            [{"level": level.upper(), "category": "mylog",
+              "text": level + "z", "context": session._context.traceId}
+             for level in ["debug", "info", "warn", "error", "critical"]])
+
+    def test_format(self):
+        """MDKHandler uses Python stdlib formatting."""
+        logger = logging.Logger("mylog")
+        mdk, tracer = create_mdk()
+        session = mdk.session()
+        logger.addHandler(MDKHandler(lambda: session))
+
+        logger.info("hello %s", "world")
+        self.assertEqual(tracer.messages[0]["text"], "hello world")
+
+    def test_noInfiniteLoops(self):
+        """
+        Sometimes MDK logging results in native, i.e. Python logging. Ensure this
+        doesn't cause infinite loop when we route Python logging to MDK.
+        """
+        mdk, tracer = create_mdk()
+        # Make logging into MDK log back into Python logging:
+        tracer.log = lambda *args, **kwargs: logging.info("hello!")
+        handler = MDKHandler(lambda: mdk.session())
+
+        root_logger = logging.getLogger()
+        root_logger.addHandler(handler)
+        self.addCleanup(lambda: root_logger.removeHandler(handler))
+        logging.error("zoop")


### PR DESCRIPTION
Provide a `logging.Handler` that uses the MDK session from the Flask request, or a default session if logging happens outside of the context of a request.

The `Logger` name is used as the category, e.g. if I do:

```
logger = Logger("hello")
logger.addHandler(MDKLoggingHandler(mdk))
logger.info("bar")
```

this is equivalent to:

```
mdk_session.info("hello", "bar")
```
