### PR TITLE
Environment support, part 1

### DIFF
--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -564,16 +564,6 @@ namespace mdk_discovery {
             return self;
         }
 
-        @doc("Register info about a service node with the discovery service. You must")
-        @doc("usually start the uplink before this will do much; see start().")
-        Discovery register_service(String service, String address, String version) {
-            Node node = new Node();
-            node.service = service;
-            node.address = address;
-            node.version = version;
-            return self.register(node);
-        }
-
         @doc("Get the service->Cluster mapping for an Environment.")
         Map<String,Cluster> _getServices(String environment) {
             if (!services.contains(environment)) {

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -370,7 +370,9 @@ namespace mdk {
                 result = new DiscoClientFactory(_wsclient);
             } else {
                 if (config.startsWith("synapse:path=")) {
-                    result = mdk_discovery.synapse.Synapse(config.substring(13, config.size()));
+                    result = mdk_discovery.synapse
+                        .Synapse(config.substring(13, config.size()),
+                                 self._environment);
                 } else {
                     if (config.startsWith("static:nodes=")) {
                         String json = config.substring(13, config.size());

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -488,6 +488,7 @@ namespace mdk {
             node.service = service;
             node.version = version;
             node.address = address;
+            node.environment = self._environment;
 
             node.properties = { "datawire_nodeId": procUUID };
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -716,7 +716,8 @@ namespace mdk {
                 }
             }
 
-            return _mdk._disco._resolve(service, version).
+            // XXX USE SESSION ENVIRONMENT
+            return _mdk._disco.resolve(service, version, "sandbox").
                 andThen(bind(self, "_resolvedCallback", []));
         }
 

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -352,6 +352,9 @@ namespace mdk {
         String procUUID = Context.runtime().uuid();
         bool _running = false;
         float _defaultTimeout = null;
+        // The Environment this MDK is configured for, e.g. "sandbox" or
+        // "production".
+        String _environment;
 
         @doc("Choose DiscoverySource based on environment variables.")
         DiscoverySourceFactory getDiscoveryFactory(EnvironmentVariables env) {
@@ -411,6 +414,8 @@ namespace mdk {
         MDKImpl(MDKRuntime runtime) {
             _reflection_hack = new Map<String,Object>();
             _runtime = runtime;
+            _environment = runtime.getEnvVarsService()
+                .var("MDK_ENVIRONMENT").orElseGet("sandbox");
             if (!runtime.dependencies.hasService("failurepolicy_factory")) {
                 runtime.dependencies.registerService("failurepolicy_factory",
                                                      getFailurePolicy(runtime));
@@ -423,7 +428,7 @@ namespace mdk {
             // Make sure we register OpenCloseSubscriber first so that Open
             // message gets sent first.
             if (_wsclient != null) {
-                _openclose = new OpenCloseSubscriber(_wsclient, procUUID);
+                _openclose = new OpenCloseSubscriber(_wsclient, procUUID, _environment);
             }
             EnvironmentVariables env = runtime.getEnvVarsService();
             DiscoverySourceFactory discoFactory = getDiscoveryFactory(env);

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -718,8 +718,7 @@ namespace mdk {
                 }
             }
 
-            // XXX USE SESSION ENVIRONMENT
-            return _mdk._disco.resolve(service, version, "sandbox").
+            return _mdk._disco.resolve(service, version, self.getEnvironment()).
                 andThen(bind(self, "_resolvedCallback", []));
         }
 

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -279,6 +279,8 @@ namespace mdk_protocol {
 
         String version = "2.0.0";
         Map<String,String> properties = {};
+        String nodeId;
+        String environment = "sandbox";  // Default environment is sandbox
     }
 
     // XXX: this should probably go somewhere in the library
@@ -368,10 +370,12 @@ namespace mdk_protocol {
         MessageDispatcher _dispatcher;
         WSClient _wsclient;
         String _node_id;
+        String _environment;
 
-        OpenCloseSubscriber(WSClient client, String node_id) {
+        OpenCloseSubscriber(WSClient client, String node_id, String environment) {
             self._wsclient = client;
             self._node_id = node_id;
+            self._environment = environment;
             self._wsclient.subscribe(self);
         }
 
@@ -403,7 +407,8 @@ namespace mdk_protocol {
         void onWSConnected(Actor websocket) {
             // Send Open message to the server:
             Open open = new Open();
-            open.properties["datawire_nodeId"] = self._node_id;
+            open.nodeId = self._node_id;
+            open.environment = _environment;
             self._dispatcher.tell(self, open.encode(), websocket);
         }
 

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -184,6 +184,13 @@ namespace mdk_protocol {
         """)
         Map<String, Object> properties = {};
 
+        @doc("""
+        The environment for this context, e.g. 'sandbox' or 'production'.
+
+        If unspecified we use 'sandbox' by default.
+        """)
+        String environment = "sandbox";
+
         int _lastEntry = 0;
 
         SharedContext() {

--- a/quark/synapse.q
+++ b/quark/synapse.q
@@ -46,11 +46,16 @@ namespace synapse {
         String directory_path;
         FileActor files;
         MessageDispatcher dispatcher;
+        String environment;
 
         _SynapseSource(Actor subscriber, String directory_path, MDKRuntime runtime) {
             self.subscriber = subscriber;
             self.directory_path = directory_path;
             self.files = runtime.getFileService();
+            // XXX
+            //self.environment = runtime.getEnvVarsService()
+            //    .var("MDK_ENVIRONMENT").orElseGet("sandbox");
+            self.environment = "whatever";
         }
 
         void onStart(MessageDispatcher dispatcher) {
@@ -70,7 +75,8 @@ namespace synapse {
 
         @doc("Send an appropriate update to the subscriber for this DiscoverySource.")
         void _update(String service, List<Node> nodes) {
-            self.dispatcher.tell(self, new ReplaceCluster(service, nodes),
+            self.dispatcher.tell(self, new ReplaceCluster(service, self.environment,
+                                                          nodes),
                                  self.subscriber);
         }
 

--- a/quark/synapse.q
+++ b/quark/synapse.q
@@ -26,13 +26,16 @@ namespace synapse {
     """)
     class Synapse extends DiscoverySourceFactory {
         String _directory_path;
+        String _environment;
 
-        Synapse(String directory_path) {
+        Synapse(String directory_path, String environment) {
             self._directory_path = directory_path;
+            self._environment = environment;
         }
 
         DiscoverySource create(Actor subscriber, MDKRuntime runtime) {
-            return new _SynapseSource(subscriber, self._directory_path, runtime);
+            return new _SynapseSource(subscriber, self._directory_path, runtime,
+                                      self._environment);
         }
 
         bool isRegistrar() {
@@ -48,14 +51,12 @@ namespace synapse {
         MessageDispatcher dispatcher;
         String environment;
 
-        _SynapseSource(Actor subscriber, String directory_path, MDKRuntime runtime) {
+        _SynapseSource(Actor subscriber, String directory_path, MDKRuntime runtime,
+                       String environment) {
             self.subscriber = subscriber;
             self.directory_path = directory_path;
             self.files = runtime.getFileService();
-            // XXX
-            //self.environment = runtime.getEnvVarsService()
-            //    .var("MDK_ENVIRONMENT").orElseGet("sandbox");
-            self.environment = "whatever";
+            self.environment = environment;
         }
 
         void onStart(MessageDispatcher dispatcher) {

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -84,7 +84,7 @@ class TracingTest {
 
     Tracer newTracer(String url) {
         WSClient client = new WSClient(runtime, getRTPParser(), url, "the_token");
-        OpenCloseSubscriber openclose = new OpenCloseSubscriber(client, "abc");
+        OpenCloseSubscriber openclose = new OpenCloseSubscriber(client, "abc", "sandbox");
         runtime.dispatcher.startActor(openclose);
         return new Tracer(runtime, client);
     }
@@ -194,7 +194,7 @@ class DiscoveryTest {
     Discovery createDisco() {
         Discovery disco = new Discovery(runtime);
         WSClient wsclient = new WSClient(runtime, getRTPParser(), "http://url/", "");
-        OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient, "xxasa");
+        OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient, "xxasa", "sandbox");
         runtime.dispatcher.startActor(wsclient);
         runtime.dispatcher.startActor(openclose);
         self.client = ?new mdk_discovery.protocol.DiscoClientFactory(wsclient).create(disco, self.runtime);
@@ -299,7 +299,7 @@ class DiscoveryTest {
     void testResolvePreStart() {
         Discovery disco = self.createDisco();
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqual(false, promise.value().hasValue());
 
         FakeWSActor sev = startDisco(disco);
@@ -314,7 +314,7 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqual(false, promise.value().hasValue());
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
@@ -328,7 +328,7 @@ class DiscoveryTest {
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(node, ?promise.value().getValue());
     }
 
@@ -337,8 +337,8 @@ class DiscoveryTest {
     void testResolveBeforeAndBeforeNotification() {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
-        Promise promise = disco._resolve("svc", "1.0");
-        Promise promise2 = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise2 = disco.resolve("svc", "1.0", "sandbox");
         checkEqual(false, promise.value().hasValue());
         checkEqual(false, promise2.value().hasValue());
 
@@ -351,11 +351,11 @@ class DiscoveryTest {
     void testResolveBeforeAndAfterNotification() {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
 
-        Promise promise2 = disco._resolve("svc", "1.0");
+        Promise promise2 = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(node, ?promise.value().getValue());
         checkEqualNodes(node, ?promise2.value().getValue());
     }
@@ -367,7 +367,7 @@ class DiscoveryTest {
         Node node = doActive(sev, "svc", "addr", "1.2.3");
         doActive(sev, "svc2", "addr", "1.2.3");
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(node, ?promise.value().getValue());
     }
 
@@ -378,9 +378,9 @@ class DiscoveryTest {
         Node n1 = doActive(sev, "svc", "addr1.0", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr1.2.3", "1.2.3");
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(n1, ?promise.value().getValue());
-        promise = disco._resolve("svc", "1.1");
+        promise = disco.resolve("svc", "1.1", "sandbox");
         checkEqualNodes(n2, ?promise.value().getValue());
     }
 
@@ -388,8 +388,8 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise p1 = disco._resolve("svc", "1.0");
-        Promise p2 = disco._resolve("svc", "1.1");
+        Promise p1 = disco.resolve("svc", "1.0", "sandbox");
+        Promise p2 = disco.resolve("svc", "1.1", "sandbox");
 
         Node n1 = doActive(sev, "svc", "addr1.0", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr1.2.3", "1.2.3");
@@ -405,9 +405,9 @@ class DiscoveryTest {
         Node n1 = doActive(sev, "svc", "addr1", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr2", "1.0.0");
 
-        Promise p = disco._resolve("svc", "1.0");
+        Promise p = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(n1, ?p.value().getValue());
-        p = disco._resolve("svc", "1.0");
+        p = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(n2, ?p.value().getValue());
 
         Node failed = ?p.value().getValue();
@@ -418,9 +418,9 @@ class DiscoveryTest {
             idx = idx + 1;
         }
 
-        p = disco._resolve("svc", "1.0");
+        p = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(n1, ?p.value().getValue());
-        p = disco._resolve("svc", "1.0");
+        p = disco.resolve("svc", "1.0", "sandbox");
         checkEqualNodes(n1, ?p.value().getValue());
     }
 
@@ -428,7 +428,7 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise promise = disco._resolve("svc", "1.0");
+        Promise promise = disco.resolve("svc", "1.0", "sandbox");
         checkEqual(false, promise.value().hasValue());
 
         Active active = new Active();
@@ -446,7 +446,7 @@ class DiscoveryTest {
 
         idx = 0;
         while (idx < count*10) {
-            Node node = ?disco._resolve("svc", "1.0").value().getValue();
+            Node node = ?disco.resolve("svc", "1.0", "sandbox").value().getValue();
             checkEqual("addr" + (idx % count).toString(), node.address);
             idx = idx + 1;
         }

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -269,23 +269,6 @@ class DiscoveryTest {
         checkEqualNodes(node, active.node);
     }
 
-    void testRegisterTheNiceWay() {
-        Discovery disco = self.createDisco();
-        FakeWSActor sev = startDisco(disco);
-
-        Node node = new Node();
-        node.service = "svc";
-        node.address = "addr";
-        node.version = "1.2.3";
-        disco.register_service(node.service, node.address, node.version);
-
-        Open open = expectOpen(sev);
-        if (open == null) { return; }
-        Active active = expectActive(sev);
-        if (active == null) { return; }
-        checkEqualNodes(node, active.node);
-    }
-
     Node doActive(FakeWSActor sev, String svc, String addr, String version) {
         Active active = new Active();
         active.node = new Node();

--- a/unittests/test_discovery.py
+++ b/unittests/test_discovery.py
@@ -385,7 +385,7 @@ class FakeDiscovery(object):
     def compare(self, real_discovery):
         """Compare us to a real Discovery instance, assert same state."""
         real_services = {}
-        for name, cluster in list(real_discovery.services.items()):
+        for name, cluster in list(real_discovery.services["sandbox"].items()):
             real_services[name] = set(node.address for node in cluster.nodes)
         assert self.services == real_services
 

--- a/unittests/test_discovery.py
+++ b/unittests/test_discovery.py
@@ -297,13 +297,6 @@ class DiscoveryEnvironmentTests(TestCase):
             self.assertEqual(resolve(disco, "myservice", "1.0", "env2").address,
                              "somewhere2")
 
-    def test_environmentInheritance(self):
-        """
-        If an Environment has a parent it is checked if there are no Nodes in the
-        child Environment.
-        """
-        raise NotImplementedError("IMPLEMENT ME")
-
 
 class CircuitBreakerTests(TestCase):
     """

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -23,6 +23,9 @@ from mdk_protocol import Serializable
 from .test_discovery import create_node
 
 
+### XXXXXXX Session.resolve and friends use the Session's environment!
+
+
 class MDKInitializationTestCase(TestCase):
     """
     Tests for top-level MDK API startup.
@@ -95,9 +98,9 @@ class InteractionTestCase(TestCase):
         self.node4 = create_node("b2", "service2")
         self.all_nodes = set([self.node1, self.node2, self.node3, self.node4])
 
-        self.disco.onMessage(None, ReplaceCluster("service1",
+        self.disco.onMessage(None, ReplaceCluster("service1", "sandbox",
                                                   [self.node1, self.node2]))
-        self.disco.onMessage(None, ReplaceCluster("service2",
+        self.disco.onMessage(None, ReplaceCluster("service2", "sandbox",
                                                   [self.node3, self.node4]))
 
     def assertPolicyState(self, policies, successes, failures):

--- a/unittests/test_mdk.py
+++ b/unittests/test_mdk.py
@@ -23,9 +23,6 @@ from mdk_protocol import Serializable
 from .test_discovery import create_node
 
 
-### XXXXXXX Session.resolve and friends use the Session's environment!
-
-
 class MDKInitializationTestCase(TestCase):
     """
     Tests for top-level MDK API startup.

--- a/unittests/test_synapse.py
+++ b/unittests/test_synapse.py
@@ -19,13 +19,13 @@ class SynapseTests(TestCase):
 
     def setUp(self):
         self.runtime = fake_runtime()
-        self.runtime.getEnvVarsService().set("MDK_ENVIRONMENT", "staging")
         self.disco = Discovery(self.runtime)
         self.runtime.dispatcher.startActor(self.disco)
 
         self.directory = mkdtemp()
         self.addCleanup(lambda: rmtree(self.directory))
-        self.synapse = Synapse(self.directory).create(self.disco, self.runtime)
+        self.synapse = Synapse(self.directory, "staging").create(
+            self.disco, self.runtime)
         self.runtime.dispatcher.startActor(self.synapse)
 
     def pump(self):

--- a/unittests/test_synapse.py
+++ b/unittests/test_synapse.py
@@ -19,6 +19,7 @@ class SynapseTests(TestCase):
 
     def setUp(self):
         self.runtime = fake_runtime()
+        self.runtime.getEnvVarsService().set("MDK_ENVIRONMENT", "staging")
         self.disco = Discovery(self.runtime)
         self.runtime.dispatcher.startActor(self.disco)
 
@@ -73,7 +74,7 @@ class SynapseTests(TestCase):
         self.write("service2.json", [])
         self.pump()
         self.assertNodesEqual(
-            self.disco.knownNodes("service1"),
+            self.disco.knownNodes("service1", "staging"),
             [self.node("service1", "host1", 123),
              self.node("service1", "host2", 124)])
 
@@ -86,7 +87,7 @@ class SynapseTests(TestCase):
                                      {"host": "host4", "port": 126}])
         self.pump()
         self.assertNodesEqual(
-            self.disco.knownNodes("service1"),
+            self.disco.knownNodes("service1", "staging"),
             [self.node("service1", "host3", 125),
              self.node("service1", "host4", 126)])
 
@@ -97,18 +98,18 @@ class SynapseTests(TestCase):
         self.pump()
         self.remove("service1.json")
         self.pump()
-        self.assertNodesEqual(self.disco.knownNodes("service1"), [])
+        self.assertNodesEqual(self.disco.knownNodes("service1", "staging"), [])
 
     def test_badFormat(self):
         """An unreadable file leaves Discovery unchanged."""
         with open(os.path.join(self.directory, "service2.json"), "w") as f:
             f.write("this is not json")
         self.pump()
-        self.assertNodesEqual(self.disco.knownNodes("service2"), [])
+        self.assertNodesEqual(self.disco.knownNodes("service2", "staging"), [])
 
     def test_unexpectedFilename(self):
         """Files that don't end with '.json' are ignored."""
         self.write("service1.abcd", [{"host": "host1", "port": 123},
                                      {"host": "host2", "port": 124}])
         self.pump()
-        self.assertNodesEqual(self.disco.knownNodes("service1"), [])
+        self.assertNodesEqual(self.disco.knownNodes("service1", "staging"), [])


### PR DESCRIPTION
1. MDK loads environment from `MDK_ENVIRONMENT` env variable, falling back to "sandbox".
2. `SharedContext/Session` pass the environment around.
3. Discovery protocol understands and respects the environment.

Still unimplemented:
1. Password protection.
2. Inheritance of environments.
3. End-to-end tests of environments, blocked on MCP support in production.
