### PR TITLE
Environment inheritance

### DIFF
--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -291,6 +291,8 @@ namespace mdk_discovery {
         Map<String,FailurePolicy> _failurepolicies = {}; // Maps address->FailurePolicy
         int _counter = 0;
         FailurePolicyFactory _fpfactory;
+        // Versions that have been registered at some point in the past:
+        List<String> _registeredVersions = [];
 
         Cluster(FailurePolicyFactory fpfactory) {
             self._fpfactory = fpfactory;
@@ -338,10 +340,40 @@ namespace mdk_discovery {
             return null;
         }
 
+        @doc("""
+        Return whether node with semantically matching version was registered at
+        some point.
+        """)
+        bool matchingVersionRegistered(String version) {
+            int idx = 0;
+            while (idx < _registeredVersions.size()) {
+                if (versionMatch(version, _registeredVersions[idx])) {
+                    return true;
+                }
+                idx = idx + 1;
+            }
+            return false;
+        }
+
         @doc("Add a Node to the cluster (or, if it's already present in the cluster,")
         @doc("update its properties).  At present, this involves a linear search, so")
         @doc("very large Clusters are unlikely to perform well.")
         void add(Node node) {
+            // Register the node's version if we haven't seen it before:
+            int kdx = 0;
+            bool foundVersion = false;
+            while (kdx < _registeredVersions.size()) {
+                if (_registeredVersions[kdx] == node.version) {
+                    foundVersion = true;
+                    break;
+                }
+                kdx = kdx + 1;
+            }
+            if (!foundVersion) {
+                _registeredVersions.add(node.version);
+            }
+
+            // Create FailurePolicy for new addresses:
             if (!_failurepolicies.contains(node.address)) {
                 _failurepolicies[node.address] = self._fpfactory.create();
             }
@@ -602,6 +634,16 @@ namespace mdk_discovery {
 
             self._lock();
             Cluster cluster = _getCluster(service, environment);
+            if (!cluster.matchingVersionRegistered(version)) {
+                // We've never seen a Node registered with a matching version. So
+                // check if there is parent environment, and if so use it.
+                if (environment.find(":") != -1) {
+                    String parent = environment.split(":")[0];
+                    self._release();
+                    return resolve(service, version, parent);
+                }
+            }
+
             Node result = cluster.chooseVersion(version);
             if (result == null) {
                 cluster._addRequest(version, factory);

--- a/quark/discovery-3.0.q
+++ b/quark/discovery-3.0.q
@@ -64,9 +64,9 @@ namespace mdk_discovery {
         @doc("The name of the service.")
         String cluster;
         @doc("The Environment for all nodes in this message.")
-        String environment = "sandbox";
+        OperationalEnvironment environment = new OperationalEnvironment();
 
-        ReplaceCluster(String cluster, String environment, List<Node> nodes) {
+        ReplaceCluster(String cluster, OperationalEnvironment environment, List<Node> nodes) {
             self.nodes = nodes;
             self.cluster = cluster;
             self.environment = environment;
@@ -473,7 +473,7 @@ namespace mdk_discovery {
         @doc("Additional metadata associated with this service instance.")
         Map<String,Object> properties = {};
         @doc("The Environment the Node is in.")
-        String environment = "sandbox";
+        OperationalEnvironment environment = new OperationalEnvironment();
 
         FailurePolicy _policy = null;
 
@@ -597,15 +597,15 @@ namespace mdk_discovery {
         }
 
         @doc("Get the service to Cluster mapping for an Environment.")
-        Map<String,Cluster> _getServices(String environment) {
-            if (!services.contains(environment)) {
-                services[environment] = {};
+        Map<String,Cluster> _getServices(OperationalEnvironment environment) {
+            if (!services.contains(environment.name)) {
+                services[environment.name] = {};
             }
-            return services[environment];
+            return services[environment.name];
         }
 
         @doc("Get the Cluster for a given service and environment.")
-        Cluster _getCluster(String service, String environment) {
+        Cluster _getCluster(String service, OperationalEnvironment environment) {
             Map<String,Cluster> clusters = _getServices(environment);
             if (!clusters.contains(service)) {
                 clusters[service] = new Cluster(self._fpfactory);
@@ -617,7 +617,7 @@ namespace mdk_discovery {
         Return the current known Nodes for a service in a particular
         Environment, if any.
         """)
-        List<Node> knownNodes(String service, String environment) {
+        List<Node> knownNodes(String service, OperationalEnvironment environment) {
             return _getCluster(service, environment).nodes;
         }
 
@@ -629,7 +629,7 @@ namespace mdk_discovery {
         @doc("Resolve a service name into an available service node. You must")
         @doc("usually start the uplink before this will do much; see start().")
         @doc("The returned Promise will end up with a Node as its value.")
-        Promise resolve(String service, String version, String environment) {
+        Promise resolve(String service, String version, OperationalEnvironment environment) {
             PromiseResolver factory = new PromiseResolver(runtime.dispatcher);
 
             self._lock();
@@ -637,10 +637,10 @@ namespace mdk_discovery {
             if (!cluster.matchingVersionRegistered(version)) {
                 // We've never seen a Node registered with a matching version. So
                 // check if there is parent environment, and if so use it.
-                if (environment.find(":") != -1) {
-                    String parent = environment.split(":")[0];
+                OperationalEnvironment fallback = environment.getFallback();
+                if (fallback != null) {
                     self._release();
-                    return resolve(service, version, parent);
+                    return resolve(service, version, fallback);
                 }
             }
 
@@ -675,7 +675,8 @@ namespace mdk_discovery {
             }
         }
 
-        void _replace(String service, String environment, List<Node> nodes) {
+        void _replace(String service, OperationalEnvironment environment,
+                      List<Node> nodes) {
             self._lock();
             logger.info("replacing all nodes for " + service + " with "
                         + nodes.toString());

--- a/quark/protocol-1.0.q
+++ b/quark/protocol-1.0.q
@@ -163,6 +163,27 @@ namespace mdk_protocol {
         }
     }
 
+    @doc("""
+    An isolated environment with a name, and optionally a fallback environment.
+
+    By default the environment will be 'sandbox'.
+    """)
+    class OperationalEnvironment extends Serializable {
+        String name = "sandbox";
+        String fallbackName = null;
+
+        @doc("Return the fallback Environment, or null if there isn't one.")
+        OperationalEnvironment getFallback() {
+            if (self.fallbackName == null) {
+                return null;
+            }
+            OperationalEnvironment result = new OperationalEnvironment();
+            result.name = self.fallbackName;
+            result.fallbackName = null;
+            return result;
+        }
+    }
+
     class SharedContext extends Serializable {
         @doc("""
              Every SharedContext is given an ID at the moment of its
@@ -186,10 +207,8 @@ namespace mdk_protocol {
 
         @doc("""
         The environment for this context, e.g. 'sandbox' or 'production'.
-
-        If unspecified we use 'sandbox' by default.
         """)
-        String environment = "sandbox";
+        OperationalEnvironment environment = new OperationalEnvironment();
 
         int _lastEntry = 0;
 
@@ -287,7 +306,7 @@ namespace mdk_protocol {
         String version = "2.0.0";
         Map<String,String> properties = {};
         String nodeId;
-        String environment = "sandbox";  // Default environment is sandbox
+        OperationalEnvironment environment = new OperationalEnvironment();
     }
 
     // XXX: this should probably go somewhere in the library
@@ -377,9 +396,9 @@ namespace mdk_protocol {
         MessageDispatcher _dispatcher;
         WSClient _wsclient;
         String _node_id;
-        String _environment;
+        OperationalEnvironment _environment;
 
-        OpenCloseSubscriber(WSClient client, String node_id, String environment) {
+        OpenCloseSubscriber(WSClient client, String node_id, OperationalEnvironment environment) {
             self._wsclient = client;
             self._node_id = node_id;
             self._environment = environment;

--- a/quark/synapse.q
+++ b/quark/synapse.q
@@ -1,5 +1,6 @@
 quark 1.0;
 
+import mdk_protocol;
 import mdk_discovery;
 import mdk_runtime;
 import mdk_runtime.actors;
@@ -26,9 +27,9 @@ namespace synapse {
     """)
     class Synapse extends DiscoverySourceFactory {
         String _directory_path;
-        String _environment;
+        OperationalEnvironment _environment;
 
-        Synapse(String directory_path, String environment) {
+        Synapse(String directory_path, OperationalEnvironment environment) {
             self._directory_path = directory_path;
             self._environment = environment;
         }
@@ -49,10 +50,10 @@ namespace synapse {
         String directory_path;
         FileActor files;
         MessageDispatcher dispatcher;
-        String environment;
+        OperationalEnvironment environment;
 
         _SynapseSource(Actor subscriber, String directory_path, MDKRuntime runtime,
-                       String environment) {
+                       OperationalEnvironment environment) {
             self.subscriber = subscriber;
             self.directory_path = directory_path;
             self.files = runtime.getFileService();

--- a/quark/tests/mdk_test.q
+++ b/quark/tests/mdk_test.q
@@ -49,6 +49,7 @@ Serializable expectSerializable(FakeWSActor sev, String expectedType) {
 
 class TracingTest {
     MDKRuntime runtime;
+    OperationalEnvironment SANDBOX = new OperationalEnvironment();
 
     TracingTest() {
         self.runtime = fakeRuntime();
@@ -84,7 +85,7 @@ class TracingTest {
 
     Tracer newTracer(String url) {
         WSClient client = new WSClient(runtime, getRTPParser(), url, "the_token");
-        OpenCloseSubscriber openclose = new OpenCloseSubscriber(client, "abc", "sandbox");
+        OpenCloseSubscriber openclose = new OpenCloseSubscriber(client, "abc", SANDBOX);
         runtime.dispatcher.startActor(openclose);
         return new Tracer(runtime, client);
     }
@@ -161,6 +162,7 @@ import mdk_discovery.protocol;
 class DiscoveryTest {
     MDKRuntime runtime;
     DiscoClient client;
+    OperationalEnvironment SANDBOX = new OperationalEnvironment();
 
     void setup() {
         self.runtime = fakeRuntime();
@@ -194,7 +196,7 @@ class DiscoveryTest {
     Discovery createDisco() {
         Discovery disco = new Discovery(runtime);
         WSClient wsclient = new WSClient(runtime, getRTPParser(), "http://url/", "");
-        OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient, "xxasa", "sandbox");
+        OpenCloseSubscriber openclose = new OpenCloseSubscriber(wsclient, "xxasa", SANDBOX);
         runtime.dispatcher.startActor(wsclient);
         runtime.dispatcher.startActor(openclose);
         self.client = ?new mdk_discovery.protocol.DiscoClientFactory(wsclient).create(disco, self.runtime);
@@ -282,7 +284,7 @@ class DiscoveryTest {
     void testResolvePreStart() {
         Discovery disco = self.createDisco();
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqual(false, promise.value().hasValue());
 
         FakeWSActor sev = startDisco(disco);
@@ -297,7 +299,7 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqual(false, promise.value().hasValue());
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
@@ -311,7 +313,7 @@ class DiscoveryTest {
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(node, ?promise.value().getValue());
     }
 
@@ -320,8 +322,8 @@ class DiscoveryTest {
     void testResolveBeforeAndBeforeNotification() {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
-        Promise promise2 = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
+        Promise promise2 = disco.resolve("svc", "1.0", SANDBOX);
         checkEqual(false, promise.value().hasValue());
         checkEqual(false, promise2.value().hasValue());
 
@@ -334,11 +336,11 @@ class DiscoveryTest {
     void testResolveBeforeAndAfterNotification() {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
 
         Node node = doActive(sev, "svc", "addr", "1.2.3");
 
-        Promise promise2 = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise2 = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(node, ?promise.value().getValue());
         checkEqualNodes(node, ?promise2.value().getValue());
     }
@@ -350,7 +352,7 @@ class DiscoveryTest {
         Node node = doActive(sev, "svc", "addr", "1.2.3");
         doActive(sev, "svc2", "addr", "1.2.3");
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(node, ?promise.value().getValue());
     }
 
@@ -361,9 +363,9 @@ class DiscoveryTest {
         Node n1 = doActive(sev, "svc", "addr1.0", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr1.2.3", "1.2.3");
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(n1, ?promise.value().getValue());
-        promise = disco.resolve("svc", "1.1", "sandbox");
+        promise = disco.resolve("svc", "1.1", SANDBOX);
         checkEqualNodes(n2, ?promise.value().getValue());
     }
 
@@ -371,8 +373,8 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise p1 = disco.resolve("svc", "1.0", "sandbox");
-        Promise p2 = disco.resolve("svc", "1.1", "sandbox");
+        Promise p1 = disco.resolve("svc", "1.0", SANDBOX);
+        Promise p2 = disco.resolve("svc", "1.1", SANDBOX);
 
         Node n1 = doActive(sev, "svc", "addr1.0", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr1.2.3", "1.2.3");
@@ -388,9 +390,9 @@ class DiscoveryTest {
         Node n1 = doActive(sev, "svc", "addr1", "1.0.0");
         Node n2 = doActive(sev, "svc", "addr2", "1.0.0");
 
-        Promise p = disco.resolve("svc", "1.0", "sandbox");
+        Promise p = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(n1, ?p.value().getValue());
-        p = disco.resolve("svc", "1.0", "sandbox");
+        p = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(n2, ?p.value().getValue());
 
         Node failed = ?p.value().getValue();
@@ -401,9 +403,9 @@ class DiscoveryTest {
             idx = idx + 1;
         }
 
-        p = disco.resolve("svc", "1.0", "sandbox");
+        p = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(n1, ?p.value().getValue());
-        p = disco.resolve("svc", "1.0", "sandbox");
+        p = disco.resolve("svc", "1.0", SANDBOX);
         checkEqualNodes(n1, ?p.value().getValue());
     }
 
@@ -411,7 +413,7 @@ class DiscoveryTest {
         Discovery disco = self.createDisco();
         FakeWSActor sev = startDisco(disco);
 
-        Promise promise = disco.resolve("svc", "1.0", "sandbox");
+        Promise promise = disco.resolve("svc", "1.0", SANDBOX);
         checkEqual(false, promise.value().hasValue());
 
         Active active = new Active();
@@ -429,7 +431,7 @@ class DiscoveryTest {
 
         idx = 0;
         while (idx < count*10) {
-            Node node = ?disco.resolve("svc", "1.0", "sandbox").value().getValue();
+            Node node = ?disco.resolve("svc", "1.0", SANDBOX).value().getValue();
             checkEqual("addr" + (idx % count).toString(), node.address);
             idx = idx + 1;
         }


### PR DESCRIPTION
Basic logic: if a matching service/version pair has ever been registered in a child environment we never fall back to the parent. Otherwise if there's nothing in the child, check the parent.
