### PR TITLE
Return a LoggedMessageId from logging methods in MDK Session

### DIFF
--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -214,19 +214,19 @@ namespace mdk {
         String externalize();
 
         @doc("Record a log entry at the CRITICAL logging level.")
-        void critical(String category, String text);
+        LoggedMessageId critical(String category, String text);
 
         @doc("Record a log entry at the ERROR logging level.")
-        void error(String category, String text);
+        LoggedMessageId error(String category, String text);
 
         @doc("Record a log entry at the WARN logging level.")
-        void warn(String category, String text);
+        LoggedMessageId warn(String category, String text);
 
         @doc("Record a log entry at the INFO logging level.")
-        void info(String category, String text);
+        LoggedMessageId info(String category, String text);
 
         @doc("Record a log entry at the DEBUG logging level.")
-        void debug(String category, String text);
+        LoggedMessageId debug(String category, String text);
 
         @doc("EXPERIMENTAL: Set the logging level for the session.")
         void trace(String level);
@@ -556,6 +556,23 @@ namespace mdk {
         bool getValue() { return false; }
     }
 
+    @doc("""
+    Information about the message that was just logged.
+    """)
+    class LoggedMessageId {
+        @doc("The ID of the trace this message was logged in.")
+        String traceId;
+
+        @doc("The causal clock level within the trace.")
+        List<int> causal_level;
+
+        @doc("The operational environment.")
+        String environment;
+
+        @doc("The fallback operational environment.")
+        String environment_fallback;
+    }
+
     class SessionImpl extends Session {
 
         static Map<String,int> _levels = {"CRITICAL": 0,
@@ -672,48 +689,44 @@ namespace mdk {
             return _level(level) <= ilevel;
         }
 
-        void _log(String level, String category, String text) {
+        LoggedMessageId _log(String level, String category, String text) {
+            if (!_enabled(level)) {
+                return null;
+            }
             if (_mdk._tracer != null) {
                 if (_inLogging.getValue()) {
                     // We're being called recursively. We don't want logging
                     // inside the tracer to trigger logging to the tracer! So
                     // sadly we have to just drop the message on the floor.
-                    return;
+                    return null;
                 }
                 _inLogging.setValue(true);
-                _mdk._tracer.log(_context, _mdk.procUUID, level, category, text);
+                LogEvent evt = _mdk._tracer
+                    .log(_context, _mdk.procUUID, level, category, text);
                 _inLogging.setValue(false);
+                // XXX create LoggedMessageId from evt
+                return null;
             }
         }
 
-        void critical(String category, String text) {
-            if (_enabled("CRITICAL")) {
-                _log("CRITICAL", category, text);
-            }
+        LoggedMessageId critical(String category, String text) {
+            return _log("CRITICAL", category, text);
         }
 
-        void error(String category, String text) {
-            if (_enabled("ERROR")) {
-                _log("ERROR", category, text);
-            }
+        LoggedMessageId error(String category, String text) {
+            return _log("ERROR", category, text);
         }
 
-        void warn(String category, String text) {
-            if (_enabled("WARN")) {
-                _log("WARN", category, text);
-            }
+        LoggedMessageId warn(String category, String text) {
+            return _log("WARN", category, text);
         }
 
-        void info(String category, String text) {
-            if (_enabled("INFO")) {
-                _log("INFO", category, text);
-            }
+        LoggedMessageId info(String category, String text) {
+            return _log("INFO", category, text);
         }
 
-        void debug(String category, String text) {
-            if (_enabled("DEBUG")) {
-                _log("DEBUG", category, text);
-            }
+        LoggedMessageId debug(String category, String text) {
+            return _log("DEBUG", category, text);
         }
 
         Promise _resolve(String service, String version) {

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -701,8 +701,9 @@ namespace mdk {
                     return null;
                 }
                 _inLogging.setValue(true);
-                LogEvent evt = _mdk._tracer
-                    .log(_context, _mdk.procUUID, level, category, text);
+                LogEvent evt = logToTracer(_mdk._tracer, _context,
+                                           _mdk.procUUID, level, category,
+                                           text);
                 _inLogging.setValue(false);
                 // XXX create LoggedMessageId from evt
                 return null;

--- a/quark/mdk-2.0.q
+++ b/quark/mdk-2.0.q
@@ -564,13 +564,21 @@ namespace mdk {
         String traceId;
 
         @doc("The causal clock level within the trace.")
-        List<int> causal_level;
+        List<int> causalLevel;
 
         @doc("The operational environment.")
         String environment;
 
         @doc("The fallback operational environment.")
-        String environment_fallback;
+        String environmentFallback;
+
+        LoggedMessageId(String traceId, List<int> causalLevel,
+                        String environment, String environmentFallback) {
+            self.traceId = traceId;
+            self.causalLevel = causalLevel;
+            self.environment = environment;
+            self.environmentFallback = environmentFallback;
+        }
     }
 
     class SessionImpl extends Session {
@@ -705,8 +713,10 @@ namespace mdk {
                                            _mdk.procUUID, level, category,
                                            text);
                 _inLogging.setValue(false);
-                // XXX create LoggedMessageId from evt
-                return null;
+                return new LoggedMessageId(_context.traceId,
+                                           evt.context.clock.clocks,
+                                           _context.environment.name,
+                                           _context.environment.fallbackName);
             }
         }
 

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -48,9 +48,8 @@ namespace mdk_tracing {
     }
 
     @doc("Construct a LogEvent and write to a tracer.")
-    LogEvent logToTracer(TracingDestination tracer,
-                         SharedContext ctx, String procUUID, String level,
-                         String category, String text) {
+    LogEvent createLogEvent(SharedContext ctx, String procUUID, String level,
+                            String category, String text) {
         ctx.tick();
         LogEvent evt = new LogEvent();
 
@@ -71,7 +70,6 @@ namespace mdk_tracing {
         evt.category = category;
         evt.contentType = "text/plain";
         evt.text = text;
-        tracer.log(evt);
         return evt;
     }
 

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -43,20 +43,45 @@ namespace mdk_tracing {
 
     @doc("MDK can use this to handle logging on the Session.")
     interface TracingDestination extends Actor {
-        @doc("Send a log message to the server.")
-        LogEvent log(SharedContext ctx, String procUUID, String level,
-                     String category, String text);
+        @doc("Send a log message to the server. Call using logToTracer().")
+        void log(LogEvent event);
+    }
+
+    @doc("Construct a LogEvent and write to a tracer.")
+    LogEvent logToTracer(TracingDestination tracer,
+                         SharedContext ctx, String procUUID, String level,
+                         String category, String text) {
+        ctx.tick();
+        LogEvent evt = new LogEvent();
+
+        // Copy context so multiple events don't have the same
+        // context object, which is getting mutated over time,
+        // e.g., the ctx.tick() call above. This potentially
+        // duplicates a large amount of baggage (ctx.properties),
+        // but hopefully that baggage is empty/unused right now.
+        // Perhaps a better workaround would be to send just the
+        // relevant data from the context object. An actual
+        // solution would involve having sensible definitions/APIs
+        // for the context object and its clock.
+
+        evt.context = ctx.copy();
+        evt.timestamp = now();
+        evt.node = procUUID;
+        evt.level = level;
+        evt.category = category;
+        evt.contentType = "text/plain";
+        evt.text = text;
+        tracer.log(evt);
+        return evt;
     }
 
     @doc("In-memory testing of logs.")
     class FakeTracer extends TracingDestination {
         List<Map<String,String>> messages = [];
 
-        LogEvent log(SharedContext ctx, String procUUID, String level,
-                 String category, String text) {
-            messages.add({"level": level, "category": category,
-                          "text": text, "context": ctx.traceId});
-            return null; // XXX move LogEvent creation into function
+        void log(LogEvent event) {
+            messages.add({"level": event.level, "category": event.category,
+                          "text": event.text, "context": event.context.traceId});
         }
 
         void onStart(MessageDispatcher dispatcher) {}
@@ -102,32 +127,9 @@ namespace mdk_tracing {
         void onMessage(Actor origin, Object mesage) {}
 
         @doc("Send a log message to the server.")
-        LogEvent log(SharedContext ctx, String procUUID, String level,
-                     String category, String text) {
-            ctx.tick();
-            logger.trace("CTX " + ctx.toString());
-
-            LogEvent evt = new LogEvent();
-
-            // Copy context so multiple events don't have the same
-            // context object, which is getting mutated over time,
-            // e.g., the ctx.tick() call above. This potentially
-            // duplicates a large amount of baggage (ctx.properties),
-            // but hopefully that baggage is empty/unused right now.
-            // Perhaps a better workaround would be to send just the
-            // relevant data from the context object. An actual
-            // solution would involve having sensible definitions/APIs
-            // for the context object and its clock.
-
-            evt.context = ctx.copy();
-            evt.timestamp = now();
-            evt.node = procUUID;
-            evt.level = level;
-            evt.category = category;
-            evt.contentType = "text/plain";
-            evt.text = text;
-            _client.log(evt);
-            return evt;
+        void log(LogEvent event) {
+            logger.trace("CTX " + event.context.toString());
+            _client.log(event);
         }
 
         void subscribe(UnaryCallable handler) {

--- a/quark/tracing-2.0.q
+++ b/quark/tracing-2.0.q
@@ -44,18 +44,19 @@ namespace mdk_tracing {
     @doc("MDK can use this to handle logging on the Session.")
     interface TracingDestination extends Actor {
         @doc("Send a log message to the server.")
-        void log(SharedContext ctx, String procUUID, String level,
-                 String category, String text);
+        LogEvent log(SharedContext ctx, String procUUID, String level,
+                     String category, String text);
     }
 
     @doc("In-memory testing of logs.")
     class FakeTracer extends TracingDestination {
         List<Map<String,String>> messages = [];
 
-        void log(SharedContext ctx, String procUUID, String level,
+        LogEvent log(SharedContext ctx, String procUUID, String level,
                  String category, String text) {
             messages.add({"level": level, "category": category,
                           "text": text, "context": ctx.traceId});
+            return null; // XXX move LogEvent creation into function
         }
 
         void onStart(MessageDispatcher dispatcher) {}
@@ -101,8 +102,8 @@ namespace mdk_tracing {
         void onMessage(Actor origin, Object mesage) {}
 
         @doc("Send a log message to the server.")
-        void log(SharedContext ctx, String procUUID, String level,
-                 String category, String text) {
+        LogEvent log(SharedContext ctx, String procUUID, String level,
+                     String category, String text) {
             ctx.tick();
             logger.trace("CTX " + ctx.toString());
 
@@ -126,6 +127,7 @@ namespace mdk_tracing {
             evt.contentType = "text/plain";
             evt.text = text;
             _client.log(evt);
+            return evt;
         }
 
         void subscribe(UnaryCallable handler) {

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -9,6 +9,7 @@ from mdk_runtime import fakeRuntime
 from mdk_discovery import CircuitBreakerFactory, Node
 from mdk_protocol import Serializable
 from mdk import MDKImpl, _parseEnvironment
+from mdk_tracing import FakeTracer
 
 
 def fake_runtime():
@@ -34,6 +35,19 @@ def create_node(address, service="myservice", environment="sandbox"):
 
 SANDBOX_ENV = _parseEnvironment("sandbox")
 
+
+def create_mdk_with_faketracer():
+    """Create an MDK with a FakeTracer.
+
+    Returns (mdk, fake_tracer).
+    """
+    runtime = fakeRuntime()
+    tracer = FakeTracer()
+    runtime.dependencies.registerService("tracer", tracer)
+    runtime.getEnvVarsService().set("MDK_DISCOVERY_SOURCE", "static:nodes={}")
+    mdk = MDKImpl(runtime)
+    mdk.start()
+    return mdk, tracer
 
 class MDKConnector(object):
     """Manage an interaction with fake remote server."""

--- a/unittests/common.py
+++ b/unittests/common.py
@@ -36,7 +36,7 @@ def create_node(address, service="myservice", environment="sandbox"):
 SANDBOX_ENV = _parseEnvironment("sandbox")
 
 
-def create_mdk_with_faketracer():
+def create_mdk_with_faketracer(environment="sandbox"):
     """Create an MDK with a FakeTracer.
 
     Returns (mdk, fake_tracer).
@@ -45,6 +45,7 @@ def create_mdk_with_faketracer():
     tracer = FakeTracer()
     runtime.dependencies.registerService("tracer", tracer)
     runtime.getEnvVarsService().set("MDK_DISCOVERY_SOURCE", "static:nodes={}")
+    runtime.getEnvVarsService().set("MDK_ENVIRONMENT", environment)
     mdk = MDKImpl(runtime)
     mdk.start()
     return mdk, tracer

--- a/unittests/test_tracing.py
+++ b/unittests/test_tracing.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 
 from mdk_protocol import SharedContext
-from mdk_tracing import logToTracer
+from mdk_tracing import createLogEvent
 from mdk_tracing.protocol import LogEvent
 from .common import MDKConnector
 
@@ -41,8 +41,8 @@ class TracingProtocolTests(TestCase):
         self.connector.mdk.start()
         self.pump()
         ctx = SharedContext()
-        logToTracer(self.connector.mdk._tracer,
-                    ctx, "procUUID", "DEBUG", "blah", "testing...")
+        event = createLogEvent(ctx, "procUUID", "DEBUG", "blah", "testing...")
+        self.connector.mdk._tracer.log(event)
         self.pump()
         ws_actor = self.connector.expectSocket()
         self.assertFalse(ws_actor == None)

--- a/unittests/test_tracing.py
+++ b/unittests/test_tracing.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 
 from mdk_protocol import SharedContext
+from mdk_tracing import logToTracer
 from mdk_tracing.protocol import LogEvent
 from .common import MDKConnector
 
@@ -40,8 +41,8 @@ class TracingProtocolTests(TestCase):
         self.connector.mdk.start()
         self.pump()
         ctx = SharedContext()
-        self.connector.mdk._tracer.log(
-            ctx, "procUUID", "DEBUG", "blah", "testing...")
+        logToTracer(self.connector.mdk._tracer,
+                    ctx, "procUUID", "DEBUG", "blah", "testing...")
         self.pump()
         ws_actor = self.connector.expectSocket()
         self.assertFalse(ws_actor == None)


### PR DESCRIPTION
1. Return the info a user would need to store the trace ID and clock levels elsewhere.
2. Return that info even if logging is *not* going to MCP.