### PR TITLE
Add trivial-to-use request.js integration to express.js integration

### DIFF
--- a/functionaltests/webservers/expressserver.js
+++ b/functionaltests/webservers/expressserver.js
@@ -2,6 +2,7 @@ var process = require('process');
 var express = require('express');
 var timeout = require('connect-timeout');
 var mdk_express = require('datawire_mdk_express');
+var request = mdk_express.request;
 mdk_express.mdk.setDefaultDeadline(10.0);
 
 var app = express();
@@ -32,6 +33,13 @@ app.get('/resolve', function (req, res) {
 
 app.get('/timeout', function (req, res) {
     res.json(req.mdk_session.getRemainingTime());
+});
+
+app.get('/http-client', function (req, res) {
+    request("http://localhost:" + process.argv[2].toString() + "/context",
+            function(error, response, body) {
+                res.send(body);
+            });
 });
 
 app.use(mdk_express.mdkErrorHandler);

--- a/javascript/datawire_mdk_express/datawire_mdk_express.js
+++ b/javascript/datawire_mdk_express/datawire_mdk_express.js
@@ -1,4 +1,5 @@
 var datawire_mdk = require('datawire_mdk');
+var mdk_request = require("datawire_mdk_request");
 var cls = require("datawire_mdk/cls.js");
 var process = require('process');
 
@@ -44,3 +45,6 @@ exports.mdkErrorHandler = function (err, req, res, next) {
 
 // Get the current session:
 exports.getMdkSession = cls.getMDKSession;
+
+// request.js wrapper that knows about cls-based MDK session:
+//exports.request = mdk_request.requestFactory(cls.getMDKSession);

--- a/javascript/datawire_mdk_express/datawire_mdk_express.js
+++ b/javascript/datawire_mdk_express/datawire_mdk_express.js
@@ -47,4 +47,4 @@ exports.mdkErrorHandler = function (err, req, res, next) {
 exports.getMdkSession = cls.getMDKSession;
 
 // request.js wrapper that knows about cls-based MDK session:
-//exports.request = mdk_request.requestFactory(cls.getMDKSession);
+exports.request = mdk_request.requestFactory(cls.getMDKSession);

--- a/javascript/datawire_mdk_express/package.json
+++ b/javascript/datawire_mdk_express/package.json
@@ -5,8 +5,8 @@
     "license": "Apache-2.0",
     "url": "https://www.datawire.io",
     "dependencies": {
-        "datawire_mdk": ">2.0.36",
-        "datawire_mdk_request": ">2.0.36"
+        "datawire_mdk": ">=2.0.36",
+        "datawire_mdk_request": ">=2.0.36"
     },
     "peerDependencies": {
         "express": "4.x"

--- a/javascript/datawire_mdk_express/package.json
+++ b/javascript/datawire_mdk_express/package.json
@@ -4,6 +4,10 @@
     "main": "datawire_mdk_express.js",
     "license": "Apache-2.0",
     "url": "https://www.datawire.io",
+    "dependencies": {
+        "datawire_mdk": ">2.0.36",
+        "datawire_mdk_request": ">2.0.36"
+    },
     "peerDependencies": {
         "express": "4.x"
     },

--- a/javascript/datawire_mdk_request/datawire_mdk_request.js
+++ b/javascript/datawire_mdk_request/datawire_mdk_request.js
@@ -41,12 +41,13 @@ function wrapRequestMethod (method, optionsFactory, requester, verb) {
     };
 }
 
-// Create a wrapper for Request that injects the MDK session header and sets an
-// appropriate timeout.
-exports.forMDKSession = function (mdkSession, requester) {
+// Create a Request.js-wrapper given a function that returns the current MDK
+// session.
+exports.requestFactory = function (getMdkSession, requester) {
     var self = request;
 
     function optionsFactory() {
+        var mdkSession = getMdkSession();
         var options = {headers: {"X-MDK-CONTEXT": mdkSession.externalize()}};
         var timeout = mdkSession.getRemainingTime() * 1000;
         if (timeout !== null) {
@@ -66,4 +67,10 @@ exports.forMDKSession = function (mdkSession, requester) {
     defaults.jar      = self.jar;
     defaults.defaults = self.defaults;
     return defaults;
+};
+
+// Create a wrapper for Request that injects the MDK session header and sets an
+// appropriate timeout.
+exports.forMDKSession = function (mdkSession, requester) {
+    return exports.requestFactory(function() { return mdkSession; }, requester);
 };


### PR DESCRIPTION
The MDK `express.js` package now includes a transparent wrapper for `request.js` that automatically gets the MDK session setup by our express middleware.